### PR TITLE
Removed spaces around pip symbol

### DIFF
--- a/radx-data-dictionary-specification.md
+++ b/radx-data-dictionary-specification.md
@@ -91,8 +91,8 @@ As an example, consider a "symptoms" field which can accept multiple values with
 |participantId|symptoms|
 |--|--|
 p1|cough
-p2|cough \| sorethroat \| headache
-p3|cough \| headache
+p2|cough\|sorethroat\|headache
+p3|cough\|headache
 
 ### Field: Datatype
 


### PR DESCRIPTION
Removed spaces around the pip symbol in the cardinality section.