### PR TITLE
Add LinkML schemas and converter plan (linkml/ subfolder)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.venv/

--- a/linkml/CONVERTER_PLAN.md
+++ b/linkml/CONVERTER_PLAN.md
@@ -1,0 +1,310 @@
+# RADx Data Dictionary → LinkML Schema Converter — Plan
+
+## Goal
+
+A Python tool that reads a RADx data dictionary in CSV format and emits a
+**LinkML schema** describing the *target datafile* that the dictionary
+documents. Each data element (row) becomes a **slot**; the datafile as a whole
+becomes a **class** (`Record`).
+
+This is *metamodeling*: the dictionary is metadata about a datafile, and the
+output schema is a formal description of that datafile's structure, suitable for
+validating the datafile with standard LinkML tooling — subject to the
+multi-value delimiter caveat noted under "Future work" (RADx bare `|` vs.
+LinkML's bracketed `[ | ]`).
+
+> Not in scope for v1 (but the parser core is shared with it): converting a data
+> *dictionary* CSV into LinkML *data instances* of the parsed object model
+> (`data-dictionary.yaml`). See "Future work".
+
+## Inputs and outputs
+
+- **Input:** one data dictionary CSV file (RFC 4180), with the header record and
+  columns defined in `radx-data-dictionary-specification.md`.
+- **Output:** one LinkML schema YAML file describing the target datafile.
+- **CLI:** `radx-dd-to-linkml INPUT.csv -o SCHEMA.yaml [--name ... --id ...]`
+
+## Core mapping: dictionary row → LinkML slot
+
+| Dictionary column | LinkML target | Notes |
+|---|---|---|
+| `Id` | slot name | Sanitized for LinkML; original kept as `slot_uri`/annotation if changed |
+| `Aliases` | `aliases:` | Native LinkML slot metadata |
+| `Label` | `title:` | |
+| `Description` | `description:` | |
+| `Section` | declared `subset` + slot `in_subset:` | See "Section grouping"; annotation only as fallback |
+| `Cardinality` | `multivalued: true` | Only when value is `multiple`; else single-valued |
+| `Terms` | `slot_uri:` (first) + `exact_mappings:` (rest) | CURIEs need prefixes registered in output |
+| `Datatype` | `range:` | Via the datatype map below |
+| `Pattern` | `pattern:` | Emitted verbatim (XSD-regex dialect) |
+| `Unit` | native `unit:` (UnitOfMeasure), lookup-assisted | See "Unit mapping"; `annotations.unit_raw` always kept |
+| `Enumeration` | generated `enum` + slot `any_of` | Range via `any_of` (see Enumeration handling) |
+| `MissingValueCodes` | shared/`per-field` enum in slot `any_of` | Augments the enum (see below) |
+| `Examples` | `examples:` | Native LinkML slot metadata (list of `{value:}`) |
+| `Notes` | `comments:` | |
+| `Provenance` | slot `source:` if URL/CURIE, else `annotations.provenance` | See "Provenance vs. source" |
+| `SeeAlso` | `see_also:` | Native |
+
+**Losslessness (decided):** every column that has no clean native LinkML home is
+preserved under `annotations:` so the conversion loses nothing and could be
+reversed.
+
+### Provenance vs. source (two different levels)
+
+These are easy to conflate but operate at different levels:
+
+- **Schema-level `source:`** — metadata about the *output schema as a whole*.
+  Set once, to the authoritative prose specification / repository it was derived
+  from (as in `data-dictionary.yaml`: the GitHub repo). Not per-field.
+- **RADx `Provenance`** — a *per-field* dictionary column: where the *definition*
+  of that field came from (typically a Common Data Element it is based on). Per
+  the spec its value is *ideally* a URL to a CDE repository, but *may* also be a
+  free-text unambiguous CDE name.
+
+Mapping (decided): map `Provenance` onto the slot's native LinkML **`source:`**
+when the value is a URL/CURIE — LinkML `source` ("where this element came from")
+is a close semantic match. When the value is free text (a CDE name), `source:`
+would fail its `uriorcurie` typing, so fall back to `annotations.provenance`.
+Either way nothing is lost. The schema-level `source:` (whole-file lineage)
+is set independently and is unaffected by this per-field mapping.
+
+### Unit mapping (decided: native `unit:`, lookup-assisted)
+
+RADx `Unit` is a single **free-text** string (the spec provides no controlled
+list) — e.g. `mm`, `mg/dL`, `degrees Celsius`. LinkML has a native `unit:` slot
+whose range is `UnitOfMeasure`, with fields: `symbol`, `abbreviation`,
+`descriptive_name`, `exact_mappings`, `ucum_code`, `derivation`,
+`has_quantity_kind`, `iec61360code`. (Verified in LinkML 1.11: a populated
+`unit:` block compiles and survives materialization with all sub-fields intact.)
+
+Mapping (decided — lookup-assisted):
+
+- The converter carries a small built-in unit table seeded from the spec's own
+  "common units" example table (23 rows: `millimeter`/`mm`/length …
+  `moles per liter`/`mol/L`/concentration). Each entry maps a unit **name or
+  symbol** → `{descriptive_name, symbol, ucum_code?}`.
+- If the RADx `Unit` value matches the table (by name **or** symbol), emit a
+  populated `unit:` block (`descriptive_name` + `symbol`, plus `ucum_code` where
+  known).
+- If it does **not** match, emit `unit: {symbol: <raw string>}` — `symbol` is the
+  fallback field, since RADx unit values are most often short symbols.
+- **In all cases**, also preserve the original cell verbatim as
+  `annotations.unit_raw` so the un-normalized string is always recoverable and
+  the mapping is lossless (a table match must never silently discard the raw
+  input).
+
+Deliberately **not** doing UCUM validation / QUDT `has_quantity_kind` resolution
+in v1: RADx units are free-text and many will not be valid UCUM, so requiring a
+UCUM library would reject legitimate data. `ucum_code` is populated only for the
+table-known units. This can be revisited later.
+
+### Section grouping (decided: `in_subset` + declared `subsets:`)
+
+`Section` is the one field about *relationships between rows* rather than a
+single row: multiple data elements share a section name (e.g. `Demographics`),
+so it is a grouping of fields. Mapping (decided):
+
+- Collect the distinct `Section` values across the dictionary and emit one
+  entry per section in the schema's `subsets:` block (section name → subset,
+  with the name as its `description`).
+- On each slot, set `in_subset: [<its section>]`.
+- Fall back to `annotations.section` only when a section name cannot be
+  sanitized into a valid subset name, so the mapping stays lossless.
+
+`in_subset` was chosen over `slot_group` because it directly models what
+`Section` is — a flat label tagging each field with the group it belongs to —
+and needs no `slot_usage` scaffolding. (`slot_group` was also verified to work
+in LinkML 1.11 and could be added later for form/section-header rendering
+tools, but is not needed for the core grouping semantics.) Both `in_subset` and
+the `subsets:` declarations were verified to survive schema materialization
+(`SchemaView` resolves `in_subset` on induced slots and lists the subsets).
+
+## Datatype mapping (decided: emit custom LinkML types)
+
+Direct built-in mappings (RADx name → LinkML built-in range):
+
+| RADx / XSD | LinkML built-in |
+|---|---|
+| `string`, `normalizedString`, `token`, `Name`, `NCName`, `language`, `NMTOKEN`, `QName`, etc. | `string` |
+| `integer`, `int`, `short`, `byte`, `long`, `nonNegativeInteger`, `positiveInteger`, `unsignedInt`, ... | `integer` |
+| `decimal` | `decimal` |
+| `float` | `float` |
+| `double` | `double` |
+| `boolean` | `boolean` |
+| `date` | `date` |
+| `dateTime` | `datetime` |
+| `time` | `time` |
+| `anyURI` | `uri` |
+
+Types with **no** LinkML built-in → the converter emits a **custom `type`** into
+the output schema's `types:` block, so the schema is self-contained:
+
+| RADx / XSD | Emitted custom type |
+|---|---|
+| `date_mdy` | `typeof: date`, `pattern: '^\d{2}/\d{2}/\d{4}$'` (US mm/dd/yyyy) |
+| `date_dmy` | `typeof: date`, `pattern: '^\d{2}/\d{2}/\d{4}$'` (intl dd/mm/yyyy) |
+| `timestamp` | `typeof: integer`, `pattern: '^[0-9]+$'` (Unix long) |
+| `gYearMonth`, `gYear`, `gMonthDay`, `gDay`, `gMonth` | `typeof: string` + XSD `pattern`, `uri: xsd:<name>` |
+| `duration`, `hexBinary`, `base64Binary`, `NOTATION`, ID/IDREF(S)/ENTITY(IES) | `typeof: string`, `uri: xsd:<name>` |
+
+Every emitted custom type carries `uri: xsd:<name>` (or the RADx meaning) so the
+provenance of the type is explicit. Only the custom types *actually used* by the
+input are emitted.
+
+**Case sensitivity:** datatype names are case-sensitive per the spec; the map
+keys are exact. An unknown/mis-cased datatype is a hard error (see errors).
+
+## Enumeration handling
+
+- Each non-blank `Enumeration` cell → a named `enum` in the output schema.
+- Enum name: `{SanitizedSlotId}Enum` (collision-checked; deduped if two slots
+  carry an identical enumeration → shared enum).
+- Each value-label pair → a `permissible_value`:
+  - key = the (unquoted) value,
+  - `description` = the label,
+  - `meaning:` = the term IRI/CURIE if present (`(UBERON:...)`).
+- **`Datatype` + `Enumeration` interaction:** when both are present, the
+  enumeration is the controlling set of values; the underlying `Datatype` is
+  preserved as `annotations.value_datatype` so the value type is not lost.
+
+### Missing-value codes augment the enum (Option 3: slot-level `any_of`)
+
+Missing-value codes and enumerations are the same value=label shape, and the
+standard missing-value codes are a shared set repeated across every enumerated
+field. To avoid repeating ~25 codes in every enum while still permitting them as
+values, the converter models the slot's range as a **union** of the field enum
+and a **shared** missing-value-codes enum:
+
+```yaml
+slots:
+  SampleType:
+    any_of:
+      - range: SampleTypeEnum            # the field's own values
+      - range: StandardMissingValueCodes # shared; defined once per schema
+```
+
+- The converter emits **one** `StandardMissingValueCodes` enum per output schema
+  (the 25 default codes from the spec) and references it by name from every
+  enumerated field's `any_of`. No repetition.
+- If a field's row carries its **own** non-blank `MissingValueCodes` cell, the
+  converter emits a field-specific `{SanitizedSlotId}MissingValueCodes` enum and
+  adds it as a **third** `any_of` branch. This realizes the spec's "augment, not
+  replace" rule: field-specific codes are added on top of the standard set.
+- A datafile value is valid iff it is a member of the field enum **or** the
+  standard codes **or** (if present) the field-specific codes.
+
+**Why not enum `inherits:` / `mixins:`?** The natural-looking approach — have
+each field enum `inherits:` from `StandardMissingValueCodes` — was tested
+against LinkML 1.11 and **does not work**: `inherits:` parses but the inherited
+permissible values are not merged by `gen-json-schema`, by `gen-linkml`
+derivation, or by `SchemaView.induced_enum`/`enum_ancestors` (all return only
+the field's own values). Slot-level `any_of` with two enum ranges was verified
+to enforce correctly: a real value passes, a standard code passes (augment), and
+an out-of-set value is rejected ("not valid under any of the given schemas").
+This is why Option 3 (union at the slot) is used rather than enum inheritance.
+
+## Architecture
+
+```
+radx_dd_converter/
+  reader.py        # RFC-4180 CSV -> list[Row]; validates required headers, ordering
+  grammar/
+    enumeration.lark   # EBNF from spec section "Semantics of Enumeration Values"
+    parse.py           # cell string -> [EnumItem(value,label,iri?)]; also MissingValueCodes
+    terms.py           # split Terms cell -> [iri|curie] (ws / NBSP / newline)
+  datatypes.py     # RADx datatype name -> LinkML range | CustomTypeSpec
+  missing_values.py # the 25 standard missing-value codes (constant) -> StandardMissingValueCodes enum
+  units.py         # built-in unit table (from the spec) -> UnitOfMeasure lookup by name/symbol
+  emit.py          # rows + parsed cells -> linkml_runtime SchemaDefinition -> YAML
+                   #   emits shared StandardMissingValueCodes enum once; wires
+                   #   enumerated slots as any_of [field enum, standard codes, (field codes)]
+  cli.py           # argparse entry point
+tests/
+  fixtures/        # small CSVs incl. the spec's own worked examples
+  test_reader.py test_parse.py test_datatypes.py test_emit.py test_e2e.py
+```
+
+**Two layers, cleanly separated:**
+1. **Parser layer** (`grammar/`) — turns cell mini-grammars into Python objects.
+   Driven by the EBNF already in the spec (Lark). *Reused verbatim if we later
+   add data-instance output.*
+2. **Emitter layer** (`emit.py`) — builds a `SchemaDefinition` using
+   `linkml_runtime` and dumps it. Building the object model (not string
+   templating) means the output is guaranteed well-formed and we can
+   `linkml-lint` it in tests.
+
+## Error handling
+
+- Missing required header (`Id`, `Label`, `Datatype`) → fail fast, name the column.
+- Unknown / mis-cased datatype name → error listing the offending value + row.
+- Malformed `Enumeration` / `MissingValueCodes` cell → parser error with the
+  cell content and row index.
+- Duplicate `Id`, or an `Alias` colliding with an `Id`/alias → error (the spec's
+  uniqueness rule).
+- Unresolvable CURIE prefix in `Terms`/enum `meaning` → warn, emit the CURIE
+  anyway, and add the prefix as a `TODO` annotation.
+
+## Validation strategy
+
+- Unit-test each layer against the spec's own examples (`"0"=[Saliva] | ...`,
+  the standard MissingValueCodes set, `^[NP](\d+)$`, etc.).
+- End-to-end: convert a fixture CSV, then run `linkml-lint` on the *output*
+  schema in-test and assert 0 errors — the converter must always emit a valid
+  schema.
+
+## Open questions / decisions still to make
+
+1. **Prefixes for `Terms`/`meaning` CURIEs.** OBO ids expand deterministically
+   (`MONDO:0004979` → `http://purl.obolibrary.org/obo/MONDO_0004979`). Do we
+   (a) always expand to full IRIs, or (b) register prefixes in the output
+   schema's `prefixes:` and keep CURIEs? (Leaning (b), with OBO expansion as a
+   known prefix map.)
+2. **Class name / schema id.** Derived from CLI flags, filename, or a dictionary
+   metadata row? (Start: CLI flags with filename fallback.)
+3. **Packaging.** Standalone script vs. installable package with an entry point.
+   Where does it live — this repo, or a sibling repo?
+
+## Future work (not v1)
+
+Two distinct CSVs must not be confused here:
+
+- a **data dictionary CSV** — the metadata; rows are data elements
+  (Id, Label, Datatype, ...);
+- a **datafile CSV** — the actual study data; rows are participant records
+  (`N001`, `67`, ...). The dictionary *describes* this file's columns.
+
+Future items:
+
+- **Data dictionary CSV → DataElement instances** (instances of
+  `data-dictionary.yaml`, the parsed object model). This is a genuine project: it
+  reuses the `grammar/` parser layer to turn the in-cell mini-grammars
+  (`Enumeration`, `Terms`, `MissingValueCodes`) into nested objects — the one
+  piece LinkML tooling cannot provide.
+- **Datafile CSV → data instances of the generated schema.** This is *almost*
+  free with stock `linkml-convert`, but **not entirely**: RADx multi-valued
+  cells use a **bare** pipe (`cough|headache`) whereas LinkML's CSV convention
+  is a **bracketed** pipe (`[cough|headache]`), and LinkML's CSV reader does not
+  split a bare-pipe (or space-separated) cell at all (see the tested note
+  below). So this needs a small **delimiter-normalization** pre-processing step
+  (rewrite RADx bare-pipe cells to `[a|b|c]`, or a custom loader) before
+  `linkml-convert` can be used. It is not a no-op.
+- Reverse direction: LinkML schema → RADx data dictionary CSV.
+
+## Tested note: LinkML in-cell multi-value behavior (LinkML 1.11)
+
+Verified empirically with `linkml-convert` on this machine:
+
+- **Reading CSV → instances:** for a `multivalued: true` slot, a cell containing
+  `cough|sorethroat|headache` is loaded as a **single-element list holding the
+  whole string** `"cough|sorethroat|headache"` — LinkML does **not** split on
+  `|`. A space-separated cell (`cough sorethroat headache`) is likewise not
+  split. There is no built-in "split this cell on a delimiter" for arbitrary
+  input.
+- **Writing instances → CSV:** a multivalued slot with values `[cough, headache]`
+  is emitted as `[cough|headache]` — pipe-separated **and wrapped in square
+  brackets**.
+
+Consequence: RADx (bare `|`) and LinkML (bracketed `[ | ]`) multi-value cell
+conventions are **not interchangeable**, even though both use the pipe
+character. Any datafile round-trip through stock LinkML tooling must normalize
+the delimiter first, or the values are silently mis-read as one string.

--- a/linkml/data-dictionary-csv.yaml
+++ b/linkml/data-dictionary-csv.yaml
@@ -2,7 +2,7 @@
 #
 # This schema models a data dictionary EXACTLY as it appears on the wire: a
 # single CSV file in which each row is one DataElement and every column is a
-# single string cell. Structure that the companion schema (specification.yaml)
+# single string cell. Structure that the companion schema (data-dictionary.yaml)
 # models as nested objects -- enumerations, missing-value codes and ontology
 # terms -- is, in the CSV, encoded INSIDE a single string cell using the
 # mini-grammars defined in the specification (e.g. `"0"=[Saliva] | "1"=[Blood]`).
@@ -14,7 +14,7 @@
 # one column per attribute, one row per data element.
 #
 # For the parsed, object-oriented model (useful once cell grammars have been
-# parsed) see specification.yaml in this repository.
+# parsed) see data-dictionary.yaml in this repository.
 #
 # NOTE: the `id` and the `dd` prefix use a w3id.org permanent identifier. The
 # redirect for this namespace still needs to be registered at

--- a/linkml/data-dictionary.yaml
+++ b/linkml/data-dictionary.yaml
@@ -1,0 +1,322 @@
+# NOTE: the `id` and the `dd` prefix use a w3id.org permanent identifier. The
+# redirect for this namespace still needs to be registered at
+# https://github.com/perma-id/w3id.org before these URIs will resolve.
+id: https://w3id.org/radx/data-dictionary
+name: radxdatadictionary
+title: RADx Data Dictionary Schema
+description: >-
+  A LinkML rendering of the RADx Data Dictionary Specification. It models a RADx
+  data dictionary as a list of DataElement records, each describing one field
+  (column) of a target datafile. See the `source` for the authoritative prose
+  specification.
+license: https://opensource.org/licenses/BSD-2-Clause
+version: 0.1.0
+source: https://github.com/bmir-radx/radx-data-dictionary-specification
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  dd: https://w3id.org/radx/data-dictionary/
+default_prefix: dd
+
+imports:
+  - linkml:types
+
+
+classes:
+
+  DataElement:
+    description: >-
+      A single record in a data dictionary, describing the features of one field
+      (column) in a target datafile. There is exactly one DataElement per
+      datafile field, and the order of DataElements corresponds to the order of
+      the fields in the target datafile.
+    attributes:
+
+      # --- Identity -------------------------------------------------------
+
+      Id:
+        identifier: true
+        required: true
+        range: string
+        description: >-
+          The Id field in the data dictionary specifies an identifier for the
+          datafile field being described. Datafile field identifiers are
+          strings. To cater for pre-existing RADx study data we do not impose
+          any restrictions on the format or characters that make up a field
+          identifier. Field identifiers may contain spaces.
+
+      Aliases:
+        range: string
+        multivalued: true
+        description: >-
+          The Aliases field in the data dictionary specifies a list of
+          alternative or previous identifiers for the datafile field being
+          described. Recording former identifiers as aliases allows a datafile
+          that uses an older identifier in its header record to be keyed to the
+          correct data dictionary record. Like the Id, aliases are strings with
+          no restrictions on their characters and may contain spaces. Aliases
+          MUST be unique across the whole data dictionary: an alias MUST NOT be
+          equal to the Id or an alias of any other record, so that any
+          identifier resolves to at most one data dictionary record.
+
+      # --- Human-readable metadata ----------------------------------------
+
+      Label:
+        required: true
+        range: string
+        description: >-
+          The Label field in the data dictionary specifies a presentation label
+          for the datafile field being described. Labels are strings; they may
+          be a human readable form of the Id. In the case where data represents
+          the response to survey questions, the label is often the text of the
+          question that was asked.
+
+      Description:
+        required: false
+        range: string
+        description: >-
+          The Description field in the data dictionary specifies a detailed
+          textual definition, explanation or context, of the field being
+          described. We strongly recommend that the Description field is filled
+          (in addition to other fields) out so that a third party that is trying
+          to understand the meaning of a field in a data dictionary can do so in
+          an unambiguous way.
+
+      Section:
+        required: false
+        range: string
+        description: >-
+          The Section field in the data dictionary specifies a section, or
+          group name, for each entry. Section names may be used for organizing
+          or clarifying purposes and are optional.
+
+      # --- Value constraints ----------------------------------------------
+
+      Cardinality:
+        range: CardinalityEnum
+        ifabsent: CardinalityEnum(single)
+        description: >-
+          The Cardinality field in the data dictionary specifies whether a field
+          is expected to be single valued or multi-valued in a datafile.
+          Multiple values in datafile field MUST be separated with a pipe
+          character, without surrounding white space. Acceptable values for the
+          cardinality field in the data dictionary are either single (the
+          associated datafile field has at most a single value) or multiple (the
+          associated datafile field may have multiple values). If no value is
+          specified then the default value of single is assumed.
+
+      Terms:
+        range: uriorcurie
+        multivalued: true
+        description: >-
+          The Terms field in the data dictionary specifies a list of ontology
+          terms that describe key concepts in the meaning of the field being
+          described. Multiple ontology term identifiers may be specified but
+          terms should be as specific as possible. Terms may be drawn from any
+          published ontology and are identified by IRIs, or by compact OBO
+          identifiers for terms from OBO Foundry ontologies. While not required,
+          we strongly recommend that term identifiers are resolvable.
+
+      Datatype:
+        required: true
+        range: DatatypeEnum
+        description: >-
+          The Datatype field in the data dictionary specifies a datatype name
+          that types field values. Datatype names MUST be from the set of
+          allowable datatype names and are case sensitive. If an enumeration is
+          supplied then the datatype name should be the datatype name of the
+          values in the enumeration.
+
+      Pattern:
+        range: string
+        description: >-
+          The Pattern field in the data dictionary may contain a regular
+          expression that specifies a pattern that must be matched by datafile
+          values. The complete datafile value must match the pattern. Regular
+          expressions use the XML Schema regular expression dialect and are
+          implicitly anchored.
+
+      Unit:
+        range: string
+        description: >-
+          The Unit field in the data dictionary may be used to document the
+          units for datafile values that represent quantities. Where possible we
+          recommend that SI unit names are used.
+
+      Enumeration:
+        range: EnumerationValue
+        multivalued: true
+        description: >-
+          The Enumeration field in the data dictionary specifies a controlled
+          list of values that datafile values must be drawn from. Each entry is
+          a value-label pair that may optionally carry an ontology term
+          identifier specifying the precise meaning of the value.
+
+      MissingValueCodes:
+        range: MissingValueCode
+        multivalued: true
+        description: >-
+          The MissingValueCodes field specifies codes that signify the reasons
+          for missing data values in transformcopy data files. A standard set of
+          codes always applies; codes specified here augment (are added to) that
+          standard set rather than replacing it.
+
+      # --- Documentation and provenance -----------------------------------
+
+      Examples:
+        range: string
+        multivalued: true
+        description: >-
+          The Examples field in the data dictionary may be used to provide one
+          or more example values for the datafile field being described. Unlike
+          the Notes field, examples are intended to be machine readable so that
+          they can be processed by downstream tools. Each example SHOULD be a
+          valid value for the field being described.
+
+      Notes:
+        range: string
+        description: >-
+          The Notes field in the data dictionary may be used to store
+          annotations, notes and comments on the row in the data dictionary and
+          the corresponding field in the datafile. The values of this field are
+          for human use and are not parsed to be used in a computational way.
+
+      Provenance:
+        range: string
+        description: >-
+          The Provenance field may be used to identify a Common Data Element
+          (CDE) that the field being described is based on, or any other
+          provenance for the field. Ideally the value is a URL that points to a
+          structured description of a CDE in a CDE repository, but it may also be
+          a string that represents an unambiguous name of a well-known CDE.
+
+      SeeAlso:
+        range: uri
+        description: >-
+          The SeeAlso field may be used to hold a URL that, when resolved,
+          provides further information about the data field being described.
+          Only syntactically well-formed and resolvable URLs should be entered
+          into this field.
+
+
+  EnumerationValue:
+    description: >-
+      A single value-label pair within an Enumeration, optionally carrying an
+      ontology term identifier that specifies the precise meaning of the value.
+    attributes:
+
+      value:
+        required: true
+        range: string
+        description: >-
+          The controlled value that a conforming datafile value must match. This
+          is the unquoted form of the value that appears in the datafile.
+
+      label:
+        required: true
+        range: string
+        description: A human readable label for the value.
+
+      iri:
+        range: uriorcurie
+        description: >-
+          An optional ontology term identifier, as a full IRI or a compact OBO
+          identifier, that specifies the precise meaning of the value.
+
+
+  MissingValueCode:
+    description: >-
+      A single value-label pair that gives a code signifying a reason for a
+      missing data value, together with a human readable description of that
+      reason.
+    attributes:
+
+      value:
+        required: true
+        range: string
+        description: The code that appears in the datafile to signify a missing value.
+
+      label:
+        required: true
+        range: string
+        description: A human readable description of the reason for the missing value.
+
+
+enums:
+
+  CardinalityEnum:
+    description: >-
+      Whether a datafile field is expected to hold a single value or may hold
+      multiple values. This is the set of values permitted for the Cardinality
+      field; when no value is given the default is single.
+    permissible_values:
+      single:
+        description: >-
+          The associated datafile field holds at most a single value. This is
+          the default when no cardinality is specified.
+      multiple:
+        description: >-
+          The associated datafile field may hold multiple values. Multiple
+          values within the field are separated with a pipe character, without
+          surrounding white space.
+
+  DatatypeEnum:
+    description: >-
+      The set of allowable datatype names. This is the set of XML Schema Part 2
+      built-in datatype names (the 19 primitive datatypes and the 25 datatypes
+      derived from them), extended with the RADx-specific datatype names
+      date_mdy, date_dmy and timestamp.
+    permissible_values:
+
+      # XML Schema primitive datatypes
+      string:
+      boolean:
+      decimal:
+      float:
+      double:
+      duration:
+      dateTime:
+      time:
+      date:
+      gYearMonth:
+      gYear:
+      gMonthDay:
+      gDay:
+      gMonth:
+      hexBinary:
+      base64Binary:
+      anyURI:
+      QName:
+      NOTATION:
+
+      # XML Schema datatypes derived from the primitives
+      normalizedString:
+      token:
+      language:
+      NMTOKEN:
+      NMTOKENS:
+      Name:
+      NCName:
+      ID:
+      IDREF:
+      IDREFS:
+      ENTITY:
+      ENTITIES:
+      integer:
+      nonPositiveInteger:
+      negativeInteger:
+      long:
+      int:
+      short:
+      byte:
+      nonNegativeInteger:
+      unsignedLong:
+      unsignedInt:
+      unsignedShort:
+      unsignedByte:
+      positiveInteger:
+
+      # RADx-specific datatype names
+      date_mdy:
+      date_dmy:
+      timestamp:

--- a/specification-csv.yaml
+++ b/specification-csv.yaml
@@ -1,0 +1,277 @@
+# CSV-faithful rendering of the RADx Data Dictionary Specification.
+#
+# This schema models a data dictionary EXACTLY as it appears on the wire: a
+# single CSV file in which each row is one DataElement and every column is a
+# single string cell. Structure that the companion schema (specification.yaml)
+# models as nested objects -- enumerations, missing-value codes and ontology
+# terms -- is, in the CSV, encoded INSIDE a single string cell using the
+# mini-grammars defined in the specification (e.g. `"0"=[Saliva] | "1"=[Blood]`).
+#
+# Consequently, every attribute here has range `string` (or a string-valued
+# enum), and none are `multivalued`: multiplicity lives inside the cell via the
+# pipe (`|`) or whitespace delimiters, not across columns. Generating a CSV/TSV
+# from this schema therefore yields a file that matches the published format
+# one column per attribute, one row per data element.
+#
+# For the parsed, object-oriented model (useful once cell grammars have been
+# parsed) see specification.yaml in this repository.
+#
+# NOTE: the `id` and the `dd` prefix use a w3id.org permanent identifier. The
+# redirect for this namespace still needs to be registered at
+# https://github.com/perma-id/w3id.org before these URIs will resolve.
+id: https://w3id.org/radx/data-dictionary-csv
+name: radxdatadictionarycsv
+title: RADx Data Dictionary Schema (CSV-faithful)
+description: >-
+  A CSV-faithful LinkML rendering of the RADx Data Dictionary Specification.
+  Each row of the CSV is one DataElement and every column is a single string
+  cell; rich values (enumerations, missing-value codes, ontology terms) are
+  encoded within a single cell using the grammars defined in the specification.
+  See the `source` for the authoritative prose specification.
+license: https://opensource.org/licenses/BSD-2-Clause
+version: 0.1.0
+source: https://github.com/bmir-radx/radx-data-dictionary-specification
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  dd: https://w3id.org/radx/data-dictionary-csv/
+default_prefix: dd
+
+imports:
+  - linkml:types
+
+
+classes:
+
+  DataElement:
+    description: >-
+      A single row of a data dictionary CSV, describing one field (column) of a
+      target datafile. Every column is a single string cell; there is exactly
+      one DataElement per datafile field, and the order of DataElements
+      corresponds to the order of the fields in the target datafile.
+    attributes:
+
+      # --- Identity -------------------------------------------------------
+
+      Id:
+        identifier: true
+        required: true
+        range: string
+        description: >-
+          The Id field specifies an identifier for the datafile field being
+          described. Field identifiers are strings; no restrictions are imposed
+          on their format or characters, and they may contain spaces.
+
+      Aliases:
+        range: string
+        # A pipe-delimited list of one or more non-empty items: no empty items,
+        # no leading or trailing pipe. (Uniqueness across the dictionary cannot
+        # be expressed as a per-cell pattern and is enforced by validators.)
+        pattern: '^[^|]+(\|[^|]+)*$'
+        description: >-
+          A single string cell holding a list of alternative or previous
+          identifiers for the field. Multiple aliases are separated by a pipe
+          character (`|`) without surrounding white space; for example
+          `ParticipantID|Participant Id`. Aliases MUST be unique across the
+          whole data dictionary so that any identifier resolves to at most one
+          data element.
+
+      # --- Human-readable metadata ----------------------------------------
+
+      Label:
+        required: true
+        range: string
+        description: >-
+          The Label field specifies a presentation label for the field being
+          described. Labels are strings and may be a human readable form of the
+          Id; for survey data the label is often the text of the question asked.
+
+      Description:
+        range: string
+        description: >-
+          A detailed textual definition, explanation or context for the field
+          being described.
+
+      Section:
+        range: string
+        description: >-
+          A section or group name for the entry, used for organizing or
+          clarifying purposes.
+
+      # --- Value constraints ----------------------------------------------
+
+      Cardinality:
+        range: CardinalityEnum
+        ifabsent: CardinalityEnum(single)
+        description: >-
+          Whether the datafile field is single valued (`single`) or may hold
+          multiple pipe-separated values (`multiple`). If the cell is blank the
+          value `single` is assumed.
+
+      Terms:
+        range: string
+        description: >-
+          A single string cell holding a list of ontology term identifiers that
+          describe key concepts in the meaning of the field. Multiple terms are
+          separated by white space (0x0020 or 0x00A0); where a newline is used
+          the whole cell must be quoted per RFC 4180. Terms are full IRIs, or
+          compact OBO identifiers for OBO Foundry ontologies (e.g.
+          `UBERON:0001836`).
+
+      Datatype:
+        required: true
+        range: DatatypeEnum
+        description: >-
+          A datatype name that types the field's values. Datatype names are case
+          sensitive and MUST come from the set of allowable datatype names. If
+          an enumeration is supplied, this is the datatype of the enumeration's
+          values.
+
+      Pattern:
+        range: string
+        description: >-
+          A regular expression that the complete datafile value must match.
+          Regular expressions use the XML Schema regular expression dialect and
+          are implicitly anchored.
+
+      Unit:
+        range: string
+        description: >-
+          The units for datafile values that represent quantities. Where
+          possible, SI unit names are recommended.
+
+      Enumeration:
+        range: string
+        # A pipe-delimited list of `"value"=[label]` pairs, each optionally
+        # followed by a `(term)` in round brackets. White space around `=` and
+        # `|` is not significant. Anchored so the whole cell must match.
+        pattern: '^\s*"[^"]*"\s*=\s*\[[^\]]*\](\s*\([^)]*\))?(\s*\|\s*"[^"]*"\s*=\s*\[[^\]]*\](\s*\([^)]*\))?)*\s*$'
+        description: >-
+          A single string cell holding a controlled list of values that datafile
+          values must be drawn from, in the format
+          `"value"=[label](optionalTermIRI) | ...`. Each item is a value-label
+          pair separated from surrounding items by a pipe character (`|`); an
+          ontology term identifier may optionally follow the label in round
+          brackets. For example: `"0"=[Saliva](UBERON:0001836) | "1"=[Blood]`.
+
+      MissingValueCodes:
+        range: string
+        # Same enumeration grammar as the Enumeration cell.
+        pattern: '^\s*"[^"]*"\s*=\s*\[[^\]]*\](\s*\([^)]*\))?(\s*\|\s*"[^"]*"\s*=\s*\[[^\]]*\](\s*\([^)]*\))?)*\s*$'
+        description: >-
+          A single string cell, in the same format as the Enumeration cell, of
+          codes signifying reasons for missing data values in transformcopy data
+          files. A standard set of codes always applies; codes given here augment
+          that standard set rather than replacing it. When the cell is blank only
+          the standard set applies.
+
+      # --- Documentation and provenance -----------------------------------
+
+      Examples:
+        range: string
+        # A pipe-delimited list of one or more non-empty items.
+        pattern: '^[^|]+(\|[^|]+)*$'
+        description: >-
+          A single string cell holding one or more example values for the field,
+          separated by a pipe character (`|`) without surrounding white space;
+          for example `N001|N002|P517`. Each example SHOULD be a valid value for
+          the field. Unlike Notes, examples are intended to be machine readable.
+
+      Notes:
+        range: string
+        description: >-
+          Free-text annotations, notes and comments on the row. The values of
+          this field are for human use and are not parsed computationally.
+
+      Provenance:
+        range: string
+        description: >-
+          Identifies a Common Data Element (CDE) that the field is based on, or
+          any other provenance for the field. Ideally a URL pointing to a
+          structured CDE description, but may also be an unambiguous name of a
+          well-known CDE.
+
+      SeeAlso:
+        range: uri
+        description: >-
+          A URL that, when resolved, provides further information about the
+          field. Only syntactically well-formed and resolvable URLs should be
+          entered.
+
+
+enums:
+
+  CardinalityEnum:
+    description: >-
+      Whether a datafile field holds a single value or may hold multiple values.
+      When the Cardinality cell is blank the default is single.
+    permissible_values:
+      single:
+        description: >-
+          The associated datafile field holds at most a single value. This is
+          the default when the cell is blank.
+      multiple:
+        description: >-
+          The associated datafile field may hold multiple values, separated
+          within the cell by a pipe character without surrounding white space.
+
+  DatatypeEnum:
+    description: >-
+      The set of allowable datatype names. This is the set of XML Schema Part 2
+      built-in datatype names (the 19 primitive datatypes and the 25 datatypes
+      derived from them), extended with the RADx-specific datatype names
+      date_mdy, date_dmy and timestamp.
+    permissible_values:
+
+      # XML Schema primitive datatypes
+      string:
+      boolean:
+      decimal:
+      float:
+      double:
+      duration:
+      dateTime:
+      time:
+      date:
+      gYearMonth:
+      gYear:
+      gMonthDay:
+      gDay:
+      gMonth:
+      hexBinary:
+      base64Binary:
+      anyURI:
+      QName:
+      NOTATION:
+
+      # XML Schema datatypes derived from the primitives
+      normalizedString:
+      token:
+      language:
+      NMTOKEN:
+      NMTOKENS:
+      Name:
+      NCName:
+      ID:
+      IDREF:
+      IDREFS:
+      ENTITY:
+      ENTITIES:
+      integer:
+      nonPositiveInteger:
+      negativeInteger:
+      long:
+      int:
+      short:
+      byte:
+      nonNegativeInteger:
+      unsignedLong:
+      unsignedInt:
+      unsignedShort:
+      unsignedByte:
+      positiveInteger:
+
+      # RADx-specific datatype names
+      date_mdy:
+      date_dmy:
+      timestamp:


### PR DESCRIPTION
Adds a LinkML rendering of the data dictionary specification and a design plan for a CSV→LinkML converter, all under a new `linkml/` subfolder to keep it separate from the core spec at the repo root.

## Contents of `linkml/`
- **`data-dictionary-csv.yaml`** — a **CSV-faithful** schema: one row per DataElement, every column a single string cell. The Enumeration / MissingValueCodes / Terms / Aliases / Examples grammars stay in-cell, with regex `pattern`s enforcing the Enumeration, MissingValueCodes, Aliases and Examples cell syntax. Maps 1:1 to the published CSV format.
- **`data-dictionary.yaml`** — the **parsed object model**: the same information after the cell grammars are decomposed into nested objects (`EnumerationValue`, `MissingValueCode`). Full descriptions, `Cardinality` default, the complete XSD datatype enum, and schema metadata.
- **`CONVERTER_PLAN.md`** — design plan for a Python tool that converts a RADx data dictionary CSV into a LinkML schema describing the target datafile. Documents the row→slot mapping, datatype→custom-type handling, enumeration + missing-value-codes via slot-level `any_of`, Provenance→`source:`/annotation, Section→`in_subset`, and Unit→native `unit:` (lookup-assisted). Several design choices were verified empirically against LinkML 1.11.

## Notes
- Both schemas `linkml-lint` with 0 errors.
- `CONVERTER_PLAN.md` is a **design doc only** — no converter code in this PR.
- Also ignores the local `.venv/` used for the LinkML toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)