### PR TITLE
Point to the LinkML rendering from the README and specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # RADx Data Dictionary Specification
 
 A specification for CSV data dictionaries in the RADx data hub.  You can view the specification [here](https://github.com/bmir-radx/radx-data-dictionary-specification/blob/main/radx-data-dictionary-specification.md).
+
+## LinkML Representation
+
+A [LinkML](https://linkml.io) rendering of the specification is available in the [`linkml/`](linkml/) folder:
+
+- [`linkml/data-dictionary-csv.yaml`](linkml/data-dictionary-csv.yaml) — a CSV-faithful schema: one row per data element, with every column a single string cell (rich values such as enumerations and ontology terms remain encoded in-cell using the grammars defined in the specification).
+- [`linkml/data-dictionary.yaml`](linkml/data-dictionary.yaml) — the parsed object model: the same information once the in-cell grammars have been decomposed into structured objects.
+- [`linkml/CONVERTER_PLAN.md`](linkml/CONVERTER_PLAN.md) — a design plan for a tool that converts a RADx data dictionary CSV into a LinkML schema describing the target datafile.
+
+The authoritative specification remains the Markdown document above; the LinkML schemas are a machine-processable rendering of it.

--- a/radx-data-dictionary-specification.md
+++ b/radx-data-dictionary-specification.md
@@ -16,6 +16,8 @@ All RADx datafiles SHOULD have header records.
 
 A RADx _data dictionary_ is a Comma Separated Values (CSV) file that describes how RADx _data_ contained in another CSV file, a _datafile_, is structured.  A data dictionary CSV file contains EXACTLY ONE data dictionary.
 
+A machine-processable [LinkML](https://linkml.io) rendering of this specification is available in the [`linkml/`](linkml/) folder of this repository (see the [`linkml/` README section](README.md#linkml-representation) for an overview).  This Markdown document remains the authoritative specification.
+
 ## Data Dictionary CSV Format
 
 Data dictionaries MUST use the CSV format specified by [RFC 4180](https://datatracker.ietf.org/doc/html/rfc4180#page-2).  


### PR DESCRIPTION
Adds pointers to the LinkML rendering (merged in #16) so it's discoverable.

- **README** — new "LinkML Representation" section linking `linkml/data-dictionary-csv.yaml`, `linkml/data-dictionary.yaml`, and `linkml/CONVERTER_PLAN.md`, each with a one-line description.
- **Specification Markdown** — a short pointer near the top linking the `linkml/` folder and the new README section.

Both notes state that the Markdown document remains the authoritative specification and the LinkML schemas are a machine-processable rendering of it. All links are repo-relative and resolve on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)