### PR TITLE
Add CSV → LinkML data dictionary converter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__/
 build/
 dist/
 .idea/
+
+# Local, uncommitted converter examples (may contain unpublished study metadata)
+converter/examples/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 .pytest_cache/
 build/
 dist/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 __pycache__/
 *.egg-info/
 .pytest_cache/
+build/
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .DS_Store
 .venv/
+__pycache__/
+*.egg-info/
+.pytest_cache/

--- a/converter/README.md
+++ b/converter/README.md
@@ -42,7 +42,9 @@ Feature-complete for v1. Components:
 - **CLI** (`radx_dd_converter/cli.py`) — the `radx-dd-to-linkml` console script
   ties the pipeline together: read CSV → emit schema → write YAML. Schema
   name/id/class default from the input filename and can be overridden with
-  flags. Reports read/parse/datatype errors cleanly (no traceback).
+  flags. Reports read/parse/datatype errors cleanly (no traceback). A duplicate
+  `Id` is fatal by default; `--allow-duplicates` keeps the first occurrence,
+  skips later ones, and warns.
 
 The converter is feature-complete for v1.
 

--- a/converter/README.md
+++ b/converter/README.md
@@ -86,6 +86,14 @@ values are visible at the point of use without scrolling to the `enums:` section
 - range: SampleTypeEnum  # 0=Saliva | 1=Blood
 ```
 
+`--annotate-enum-usage` does the reverse: on each field enum's definition it lists
+the data elements that use it (capped). Useful for spotting a shared enum reused
+across many fields:
+
+```yaml
+NihDisabilityEnum:  # used by: nih_disability | nih_deaf | ... (+105 more)
+```
+
 ## Usage (library)
 
 ```python

--- a/converter/README.md
+++ b/converter/README.md
@@ -24,9 +24,12 @@ Work in progress. Implemented so far:
   `CustomType` the emitter must add to the schema's `types:` block. Covers all
   47 allowable names (a test checks this against the schema's `DatatypeEnum`);
   case-sensitive, unknown names raise.
+- **Constant tables** — `missing_values.py` holds the 25 standard
+  missing-value codes (stored as the spec's verbatim default string and parsed
+  by the converter's own parser); `units.py` provides `lookup_unit`, mapping a
+  raw `Unit` cell (by name or symbol) to a structured `UnitOfMeasure`.
 
-Not yet implemented: unit/missing-value tables, the schema emitter, and the
-CLI.
+Not yet implemented: the schema emitter and the CLI.
 
 ## Development
 

--- a/converter/README.md
+++ b/converter/README.md
@@ -78,6 +78,14 @@ BIOPORTAL_API_KEY=... radx-dd-to-linkml my_dictionary.csv -o out.yaml \
     --annotate-terms --resolver bioportal
 ```
 
+`--annotate-enum-values` adds a comment after each field enum's `range:` listing
+its `value=label` pairs (capped, with a `(+N more)` overflow), so the allowed
+values are visible at the point of use without scrolling to the `enums:` section:
+
+```yaml
+- range: SampleTypeEnum  # 0=Saliva | 1=Blood
+```
+
 ## Usage (library)
 
 ```python

--- a/converter/README.md
+++ b/converter/README.md
@@ -19,9 +19,14 @@ Work in progress. Implemented so far:
     `"value"=[label](iri) | ...` syntax, driven by a Lark grammar
     (`grammar/enumeration.lark`) that mirrors the EBNF in the specification.
   - `parse_terms` — splits a `Terms` cell into IRI/CURIE tokens.
+- **Datatype mapping** (`radx_dd_converter/datatypes.py`) — `resolve_datatype`
+  maps a RADx/XSD datatype name to either a LinkML built-in range or a
+  `CustomType` the emitter must add to the schema's `types:` block. Covers all
+  47 allowable names (a test checks this against the schema's `DatatypeEnum`);
+  case-sensitive, unknown names raise.
 
-Not yet implemented: datatype mapping, unit/missing-value tables, the schema
-emitter, and the CLI.
+Not yet implemented: unit/missing-value tables, the schema emitter, and the
+CLI.
 
 ## Development
 

--- a/converter/README.md
+++ b/converter/README.md
@@ -86,12 +86,15 @@ values are visible at the point of use without scrolling to the `enums:` section
 - range: SampleTypeEnum  # 0=Saliva | 1=Blood
 ```
 
-`--annotate-enum-usage` does the reverse: on each field enum's definition it lists
-the data elements that use it (capped). Useful for spotting a shared enum reused
-across many fields:
+Each field enum also gets a 3-line comment block above its definition (always
+on) giving its number, how many data elements use it, and the referencing ids
+(capped) — useful for spotting a shared enum reused across many fields:
 
 ```yaml
-NihDisabilityEnum:  # used by: nih_disability | nih_deaf | ... (+105 more)
+# Enum 8 of 16
+# Used by 111 data elements
+# nih_disability | nih_deaf | nih_blind | ... (+105 more)
+NoYesOtherEtcEnum:
 ```
 
 ## Usage (library)

--- a/converter/README.md
+++ b/converter/README.md
@@ -37,7 +37,23 @@ Work in progress. Implemented so far:
   (lookup-assisted, raw preserved), CURIEs kept with OBO prefixes auto-
   registered. A test lints the generated schema and asserts zero errors.
 
-Not yet implemented: the CLI (`cli.py`) and its `radx-dd-to-linkml` entry point.
+- **CLI** (`radx_dd_converter/cli.py`) — the `radx-dd-to-linkml` console script
+  ties the pipeline together: read CSV → emit schema → write YAML. Schema
+  name/id/class default from the input filename and can be overridden with
+  flags. Reports read/parse/datatype errors cleanly (no traceback).
+
+The converter is feature-complete for v1.
+
+## Usage (CLI)
+
+```sh
+radx-dd-to-linkml my_dictionary.csv -o my_schema.yaml
+# override the derived identifiers:
+radx-dd-to-linkml my_dictionary.csv -o my_schema.yaml \
+    --name my_data --id https://example.org/my_data --class-name Record
+# default output is stdout:
+radx-dd-to-linkml my_dictionary.csv | head
+```
 
 ## Usage (library)
 

--- a/converter/README.md
+++ b/converter/README.md
@@ -28,8 +28,25 @@ Work in progress. Implemented so far:
   missing-value codes (stored as the spec's verbatim default string and parsed
   by the converter's own parser); `units.py` provides `lookup_unit`, mapping a
   raw `Unit` cell (by name or symbol) to a structured `UnitOfMeasure`.
+- **Emitter** (`radx_dd_converter/emit.py`) — `emit_schema(rows, options)`
+  assembles rows + parsed cells into a `linkml_runtime` `SchemaDefinition` and
+  dumps YAML. Implements the full mapping: `Datatype` → range / custom type,
+  `Enumeration` → generated enum wired via slot `any_of` with the shared
+  `StandardMissingValueCodes` (and per-field codes), `Provenance` →
+  `source:`/annotation, `Section` → `in_subset`, `Unit` → native `unit:`
+  (lookup-assisted, raw preserved), CURIEs kept with OBO prefixes auto-
+  registered. A test lints the generated schema and asserts zero errors.
 
-Not yet implemented: the schema emitter and the CLI.
+Not yet implemented: the CLI (`cli.py`) and its `radx-dd-to-linkml` entry point.
+
+## Usage (library)
+
+```python
+from radx_dd_converter import read_data_dictionary, emit_schema, EmitOptions
+
+rows = read_data_dictionary("my_dictionary.csv")
+print(emit_schema(rows, EmitOptions(schema_name="my_data", class_name="Record")))
+```
 
 ## Development
 

--- a/converter/README.md
+++ b/converter/README.md
@@ -86,9 +86,13 @@ values are visible at the point of use without scrolling to the `enums:` section
 - range: SampleTypeEnum  # 0=Saliva | 1=Blood
 ```
 
-Each field enum also gets a 3-line comment block above its definition (always
-on) giving its number, how many data elements use it, and the referencing ids
-(capped) — useful for spotting a shared enum reused across many fields:
+Comment blocks are placed above entries (always on) to make the schema easier
+to scan:
+
+- **Field enums** and **sections** get a 3-line block: its number, how many data
+  elements use it, and the referencing ids (capped) — useful for spotting a
+  shared enum or a large section.
+- **Data elements** get a 1-line block: `# Data element n of m`.
 
 ```yaml
 # Enum 8 of 16
@@ -96,6 +100,9 @@ on) giving its number, how many data elements use it, and the referencing ids
 # nih_disability | nih_deaf | nih_blind | ... (+105 more)
 NoYesOtherEtcEnum:
 ```
+
+The shared `StandardMissingValueCodes` enum is always emitted last in the
+`enums:` section.
 
 ## Usage (library)
 

--- a/converter/README.md
+++ b/converter/README.md
@@ -6,7 +6,7 @@ for the design.
 
 ## Status
 
-Work in progress. Implemented so far:
+Feature-complete for v1. Components:
 
 - **Reader** (`radx_dd_converter/reader.py`) — `read_data_dictionary` parses a
   data dictionary CSV per RFC 4180, validates the header (required columns

--- a/converter/README.md
+++ b/converter/README.md
@@ -55,7 +55,15 @@ radx-dd-to-linkml my_dictionary.csv -o my_schema.yaml \
     --name my_data --id https://example.org/my_data --class-name Record
 # default output is stdout:
 radx-dd-to-linkml my_dictionary.csv | head
+# look up ontology term names (via OLS4) and add them as YAML comments
+# (requires network; unresolved terms are skipped):
+radx-dd-to-linkml my_dictionary.csv -o my_schema.yaml --annotate-terms
 ```
+
+With `--annotate-terms`, ontology CURIEs are annotated with their labels, e.g.
+`- MONDO:0004979  # asthma`. Lookups use the EBI Ontology Lookup Service (OLS4),
+are de-duplicated and run concurrently, and any term that cannot be resolved is
+left as a bare CURIE.
 
 ## Usage (library)
 

--- a/converter/README.md
+++ b/converter/README.md
@@ -30,7 +30,9 @@ Work in progress. Implemented so far:
   raw `Unit` cell (by name or symbol) to a structured `UnitOfMeasure`.
 - **Emitter** (`radx_dd_converter/emit.py`) — `emit_schema(rows, options)`
   assembles rows + parsed cells into a `linkml_runtime` `SchemaDefinition` and
-  dumps YAML. Implements the full mapping: `Datatype` → range / custom type,
+  dumps readable YAML (multi-line descriptions as literal `|` blocks; section
+  comments and blank lines between slots/enums/types). Implements the full
+  mapping: `Datatype` → range / custom type,
   `Enumeration` → generated enum wired via slot `any_of` with the shared
   `StandardMissingValueCodes` (and per-field codes), `Provenance` →
   `source:`/annotation, `Section` → `in_subset`, `Unit` → native `unit:`

--- a/converter/README.md
+++ b/converter/README.md
@@ -1,0 +1,27 @@
+# RADx Data Dictionary → LinkML Converter
+
+A Python tool that converts a RADx data dictionary CSV into a LinkML schema
+describing the target datafile. See [`../linkml/CONVERTER_PLAN.md`](../linkml/CONVERTER_PLAN.md)
+for the design.
+
+## Status
+
+Work in progress. Implemented so far:
+
+- **Parser layer** (`radx_dd_converter/grammar/`) — parses the in-cell
+  mini-grammars used by RADx data dictionaries:
+  - `parse_enumeration` / `parse_missing_value_codes` — the
+    `"value"=[label](iri) | ...` syntax, driven by a Lark grammar
+    (`grammar/enumeration.lark`) that mirrors the EBNF in the specification.
+  - `parse_terms` — splits a `Terms` cell into IRI/CURIE tokens.
+
+Not yet implemented: the CSV reader, datatype mapping, unit/missing-value
+tables, the schema emitter, and the CLI.
+
+## Development
+
+```sh
+# from the repository root, using the project's virtualenv
+.venv/bin/pip install -e converter[test]
+.venv/bin/pytest converter
+```

--- a/converter/README.md
+++ b/converter/README.md
@@ -8,6 +8,11 @@ for the design.
 
 Work in progress. Implemented so far:
 
+- **Reader** (`radx_dd_converter/reader.py`) — `read_data_dictionary` parses a
+  data dictionary CSV per RFC 4180, validates the header (required columns
+  `Id`/`Label`/`Datatype`, duplicate detection), and returns ordered `Row`
+  objects (row order is significant). Errors on blank required cells and
+  duplicate `Id`s; preserves extra (non-canonical) columns.
 - **Parser layer** (`radx_dd_converter/grammar/`) — parses the in-cell
   mini-grammars used by RADx data dictionaries:
   - `parse_enumeration` / `parse_missing_value_codes` — the
@@ -15,8 +20,8 @@ Work in progress. Implemented so far:
     (`grammar/enumeration.lark`) that mirrors the EBNF in the specification.
   - `parse_terms` — splits a `Terms` cell into IRI/CURIE tokens.
 
-Not yet implemented: the CSV reader, datatype mapping, unit/missing-value
-tables, the schema emitter, and the CLI.
+Not yet implemented: datatype mapping, unit/missing-value tables, the schema
+emitter, and the CLI.
 
 ## Development
 

--- a/converter/README.md
+++ b/converter/README.md
@@ -61,9 +61,20 @@ radx-dd-to-linkml my_dictionary.csv -o my_schema.yaml --annotate-terms
 ```
 
 With `--annotate-terms`, ontology CURIEs are annotated with their labels, e.g.
-`- MONDO:0004979  # asthma`. Lookups use the EBI Ontology Lookup Service (OLS4),
-are de-duplicated and run concurrently, and any term that cannot be resolved is
-left as a bare CURIE.
+`- MONDO:0004979  # asthma`. Lookups are de-duplicated, run concurrently, and any
+term that cannot be resolved is left as a bare CURIE.
+
+The resolver is selectable with `--resolver`:
+
+- `ols4` (default) — the EBI Ontology Lookup Service; open, no key required.
+- `bioportal` — BioPortal; requires an API key via `BIOPORTAL_API_KEY` (or
+  `--bioportal-apikey`).
+
+```sh
+radx-dd-to-linkml my_dictionary.csv -o out.yaml --annotate-terms --resolver ols4
+BIOPORTAL_API_KEY=... radx-dd-to-linkml my_dictionary.csv -o out.yaml \
+    --annotate-terms --resolver bioportal
+```
 
 ## Usage (library)
 

--- a/converter/pyproject.toml
+++ b/converter/pyproject.toml
@@ -17,8 +17,8 @@ dependencies = [
 [project.optional-dependencies]
 test = ["pytest>=7"]
 
-# NOTE: the `radx-dd-to-linkml` console script will be added when the CLI layer
-# (radx_dd_converter/cli.py) is implemented. Only the parser layer exists today.
+[project.scripts]
+radx-dd-to-linkml = "radx_dd_converter.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/converter/pyproject.toml
+++ b/converter/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "radx-dd-converter"
+version = "0.0.1"
+description = "Convert a RADx data dictionary CSV into a LinkML schema"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "BSD-2-Clause" }
+dependencies = [
+    "lark>=1.1",
+    "linkml>=1.8",
+]
+
+[project.optional-dependencies]
+test = ["pytest>=7"]
+
+# NOTE: the `radx-dd-to-linkml` console script will be added when the CLI layer
+# (radx_dd_converter/cli.py) is implemented. Only the parser layer exists today.
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["radx_dd_converter*"]
+
+[tool.setuptools.package-data]
+radx_dd_converter = ["grammar/*.lark"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/converter/radx_dd_converter/__init__.py
+++ b/converter/radx_dd_converter/__init__.py
@@ -14,6 +14,11 @@ from .datatypes import (
     UnknownDatatypeError,
     resolve_datatype,
 )
+from .missing_values import (
+    STANDARD_ENUM_NAME,
+    STANDARD_MISSING_VALUE_CODES,
+    STANDARD_MISSING_VALUE_CODES_TEXT,
+)
 from .reader import (
     KNOWN_COLUMNS,
     REQUIRED_COLUMNS,
@@ -21,6 +26,7 @@ from .reader import (
     Row,
     read_data_dictionary,
 )
+from .units import UnitOfMeasure, lookup_unit
 
 __all__ = [
     "BUILTIN_RANGES",
@@ -28,6 +34,11 @@ __all__ = [
     "CustomType",
     "UnknownDatatypeError",
     "resolve_datatype",
+    "STANDARD_ENUM_NAME",
+    "STANDARD_MISSING_VALUE_CODES",
+    "STANDARD_MISSING_VALUE_CODES_TEXT",
+    "UnitOfMeasure",
+    "lookup_unit",
     "KNOWN_COLUMNS",
     "REQUIRED_COLUMNS",
     "ReadError",

--- a/converter/radx_dd_converter/__init__.py
+++ b/converter/radx_dd_converter/__init__.py
@@ -7,6 +7,13 @@ Python objects. It is the one piece that standard LinkML tooling cannot provide,
 because the structure is hidden inside string cells in a bespoke notation.
 """
 
+from .datatypes import (
+    BUILTIN_RANGES,
+    CUSTOM_TYPES,
+    CustomType,
+    UnknownDatatypeError,
+    resolve_datatype,
+)
 from .reader import (
     KNOWN_COLUMNS,
     REQUIRED_COLUMNS,
@@ -16,6 +23,11 @@ from .reader import (
 )
 
 __all__ = [
+    "BUILTIN_RANGES",
+    "CUSTOM_TYPES",
+    "CustomType",
+    "UnknownDatatypeError",
+    "resolve_datatype",
     "KNOWN_COLUMNS",
     "REQUIRED_COLUMNS",
     "ReadError",

--- a/converter/radx_dd_converter/__init__.py
+++ b/converter/radx_dd_converter/__init__.py
@@ -1,0 +1,10 @@
+"""Converter from RADx data dictionary CSV to a LinkML schema.
+
+This package is described in ``linkml/CONVERTER_PLAN.md``. The ``grammar``
+subpackage is the parser layer: it turns the in-cell mini-grammars used by RADx
+data dictionaries (enumerations, missing-value codes, ontology term lists) into
+Python objects. It is the one piece that standard LinkML tooling cannot provide,
+because the structure is hidden inside string cells in a bespoke notation.
+"""
+
+__all__ = []

--- a/converter/radx_dd_converter/__init__.py
+++ b/converter/radx_dd_converter/__init__.py
@@ -14,6 +14,7 @@ from .datatypes import (
     UnknownDatatypeError,
     resolve_datatype,
 )
+from .emit import EmitOptions, Emitter, emit_schema
 from .missing_values import (
     STANDARD_ENUM_NAME,
     STANDARD_MISSING_VALUE_CODES,
@@ -34,6 +35,9 @@ __all__ = [
     "CustomType",
     "UnknownDatatypeError",
     "resolve_datatype",
+    "EmitOptions",
+    "Emitter",
+    "emit_schema",
     "STANDARD_ENUM_NAME",
     "STANDARD_MISSING_VALUE_CODES",
     "STANDARD_MISSING_VALUE_CODES_TEXT",

--- a/converter/radx_dd_converter/__init__.py
+++ b/converter/radx_dd_converter/__init__.py
@@ -7,4 +7,18 @@ Python objects. It is the one piece that standard LinkML tooling cannot provide,
 because the structure is hidden inside string cells in a bespoke notation.
 """
 
-__all__ = []
+from .reader import (
+    KNOWN_COLUMNS,
+    REQUIRED_COLUMNS,
+    ReadError,
+    Row,
+    read_data_dictionary,
+)
+
+__all__ = [
+    "KNOWN_COLUMNS",
+    "REQUIRED_COLUMNS",
+    "ReadError",
+    "Row",
+    "read_data_dictionary",
+]

--- a/converter/radx_dd_converter/cli.py
+++ b/converter/radx_dd_converter/cli.py
@@ -1,0 +1,120 @@
+"""Command-line interface for the RADx data dictionary -> LinkML converter.
+
+Usage::
+
+    radx-dd-to-linkml INPUT.csv -o SCHEMA.yaml [--name ...] [--id ...] [--class-name ...]
+
+When ``--name`` / ``--id`` / ``--class-name`` are omitted they are derived from
+the input filename (e.g. ``patient_data.csv`` -> name ``patient_data``, class
+``PatientData``). Output goes to ``-o`` / ``--output`` or, by default, stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sys
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+from .datatypes import UnknownDatatypeError
+from .emit import EmitOptions, emit_schema
+from .grammar import ParseError
+from .reader import ReadError, read_data_dictionary
+
+DEFAULT_ID_BASE = "https://w3id.org/radx"
+
+
+def _name_from_filename(path: Path) -> str:
+    """Derive a schema name from an input filename.
+
+    ``gcb.dd.csv`` -> ``gcb``; ``patient_data.csv`` -> ``patient_data``. Strips
+    a trailing ``.dd`` (a common RADx data-dictionary suffix) and sanitises to a
+    LinkML-safe token.
+    """
+    stem = path.name
+    for suffix in (".csv", ".tsv"):
+        if stem.lower().endswith(suffix):
+            stem = stem[: -len(suffix)]
+            break
+    if stem.lower().endswith(".dd"):
+        stem = stem[:-3]
+    safe = re.sub(r"\W+", "_", stem).strip("_").lower()
+    return safe or "data_dictionary"
+
+
+def _class_from_name(name: str) -> str:
+    # Split on any non-alphanumeric, including underscores, so
+    # "patient_data" -> "PatientData".
+    parts = re.split(r"[^A-Za-z0-9]+", name)
+    return "".join(p[:1].upper() + p[1:] for p in parts if p) or "Record"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="radx-dd-to-linkml",
+        description="Convert a RADx data dictionary CSV into a LinkML schema.",
+    )
+    parser.add_argument("input", type=Path, help="Path to the data dictionary CSV.")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Output schema file (default: stdout).",
+    )
+    parser.add_argument("--name", default=None, help="Schema name (default: from filename).")
+    parser.add_argument("--id", dest="schema_id", default=None, help="Schema id/URI (default: derived from name).")
+    parser.add_argument(
+        "--class-name",
+        default=None,
+        help="Root class name (default: CamelCase of the name, else Record).",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show warnings (e.g. non-OBO CURIE prefixes).",
+    )
+    return parser
+
+
+def _resolve_options(args: argparse.Namespace) -> EmitOptions:
+    name = args.name or _name_from_filename(args.input)
+    class_name = args.class_name or _class_from_name(name)
+    schema_id = args.schema_id or f"{DEFAULT_ID_BASE}/{name}"
+    return EmitOptions(schema_id=schema_id, schema_name=name, class_name=class_name)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=logging.WARNING if args.verbose else logging.ERROR,
+        format="%(levelname)s: %(message)s",
+    )
+
+    if not args.input.exists():
+        print(f"error: input file not found: {args.input}", file=sys.stderr)
+        return 2
+
+    try:
+        rows = read_data_dictionary(args.input)
+        schema_yaml = emit_schema(rows, _resolve_options(args))
+    except (ReadError, ParseError, UnknownDatatypeError) as exc:
+        # Expected, user-facing errors: report cleanly without a traceback.
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output is None:
+        sys.stdout.write(schema_yaml)
+    else:
+        args.output.write_text(schema_yaml, encoding="utf-8")
+        print(
+            f"Wrote {len(rows)} data elements to {args.output}", file=sys.stderr
+        )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/converter/radx_dd_converter/cli.py
+++ b/converter/radx_dd_converter/cli.py
@@ -92,6 +92,12 @@ def _build_parser() -> argparse.ArgumentParser:
         help="BioPortal API key (overrides the BIOPORTAL_API_KEY env var).",
     )
     parser.add_argument(
+        "--allow-duplicates",
+        action="store_true",
+        help="Do not fail on a duplicate Id; keep the first occurrence, skip "
+        "later ones, and warn (shown with --verbose).",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -127,7 +133,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return 2
 
     try:
-        rows = read_data_dictionary(args.input)
+        rows = read_data_dictionary(
+            args.input, allow_duplicates=args.allow_duplicates
+        )
         schema_yaml = emit_schema(rows, _resolve_options(args))
     except (ReadError, ParseError, UnknownDatatypeError, LookupError_) as exc:
         # Expected, user-facing errors: report cleanly without a traceback.

--- a/converter/radx_dd_converter/cli.py
+++ b/converter/radx_dd_converter/cli.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import re
 import sys
 from pathlib import Path
@@ -22,6 +23,7 @@ from .datatypes import UnknownDatatypeError
 from .emit import EmitOptions, emit_schema
 from .grammar import ParseError
 from .reader import ReadError, read_data_dictionary
+from .terms_lookup import LookupError_
 
 DEFAULT_ID_BASE = "https://w3id.org/radx"
 
@@ -74,8 +76,20 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--annotate-terms",
         action="store_true",
-        help="Look up ontology term names (via OLS4) and add them as YAML "
-        "comments. Requires network access; unresolved terms are skipped.",
+        help="Look up ontology term names and add them as YAML comments. "
+        "Requires network access; unresolved terms are skipped.",
+    )
+    parser.add_argument(
+        "--resolver",
+        choices=("ols4", "bioportal"),
+        default="ols4",
+        help="Term-name resolver for --annotate-terms (default: ols4). "
+        "'bioportal' requires an API key.",
+    )
+    parser.add_argument(
+        "--bioportal-apikey",
+        default=None,
+        help="BioPortal API key (overrides the BIOPORTAL_API_KEY env var).",
     )
     parser.add_argument(
         "-v",
@@ -90,11 +104,14 @@ def _resolve_options(args: argparse.Namespace) -> EmitOptions:
     name = args.name or _name_from_filename(args.input)
     class_name = args.class_name or _class_from_name(name)
     schema_id = args.schema_id or f"{DEFAULT_ID_BASE}/{name}"
+    apikey = args.bioportal_apikey or os.environ.get("BIOPORTAL_API_KEY")
     return EmitOptions(
         schema_id=schema_id,
         schema_name=name,
         class_name=class_name,
         annotate_terms=args.annotate_terms,
+        resolver=args.resolver,
+        bioportal_apikey=apikey,
     )
 
 
@@ -112,7 +129,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     try:
         rows = read_data_dictionary(args.input)
         schema_yaml = emit_schema(rows, _resolve_options(args))
-    except (ReadError, ParseError, UnknownDatatypeError) as exc:
+    except (ReadError, ParseError, UnknownDatatypeError, LookupError_) as exc:
         # Expected, user-facing errors: report cleanly without a traceback.
         print(f"error: {exc}", file=sys.stderr)
         return 1

--- a/converter/radx_dd_converter/cli.py
+++ b/converter/radx_dd_converter/cli.py
@@ -16,7 +16,7 @@ import logging
 import re
 import sys
 from pathlib import Path
-from typing import List, Optional, Sequence
+from typing import Optional, Sequence
 
 from .datatypes import UnknownDatatypeError
 from .emit import EmitOptions, emit_schema

--- a/converter/radx_dd_converter/cli.py
+++ b/converter/radx_dd_converter/cli.py
@@ -98,12 +98,6 @@ def _build_parser() -> argparse.ArgumentParser:
         "pairs (capped, with a '(+N more)' overflow).",
     )
     parser.add_argument(
-        "--annotate-enum-usage",
-        action="store_true",
-        help="On each field enum definition, add a comment listing the data "
-        "elements that use it (capped, with a '(+N more)' overflow).",
-    )
-    parser.add_argument(
         "--allow-duplicates",
         action="store_true",
         help="Do not fail on a duplicate Id; keep the first occurrence, skip "
@@ -131,7 +125,6 @@ def _resolve_options(args: argparse.Namespace) -> EmitOptions:
         resolver=args.resolver,
         bioportal_apikey=apikey,
         annotate_enum_values=args.annotate_enum_values,
-        annotate_enum_usage=args.annotate_enum_usage,
     )
 
 

--- a/converter/radx_dd_converter/cli.py
+++ b/converter/radx_dd_converter/cli.py
@@ -98,6 +98,12 @@ def _build_parser() -> argparse.ArgumentParser:
         "pairs (capped, with a '(+N more)' overflow).",
     )
     parser.add_argument(
+        "--annotate-enum-usage",
+        action="store_true",
+        help="On each field enum definition, add a comment listing the data "
+        "elements that use it (capped, with a '(+N more)' overflow).",
+    )
+    parser.add_argument(
         "--allow-duplicates",
         action="store_true",
         help="Do not fail on a duplicate Id; keep the first occurrence, skip "
@@ -125,6 +131,7 @@ def _resolve_options(args: argparse.Namespace) -> EmitOptions:
         resolver=args.resolver,
         bioportal_apikey=apikey,
         annotate_enum_values=args.annotate_enum_values,
+        annotate_enum_usage=args.annotate_enum_usage,
     )
 
 

--- a/converter/radx_dd_converter/cli.py
+++ b/converter/radx_dd_converter/cli.py
@@ -72,10 +72,16 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Root class name (default: CamelCase of the name, else Record).",
     )
     parser.add_argument(
+        "--annotate-terms",
+        action="store_true",
+        help="Look up ontology term names (via OLS4) and add them as YAML "
+        "comments. Requires network access; unresolved terms are skipped.",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
-        help="Show warnings (e.g. non-OBO CURIE prefixes).",
+        help="Show warnings (e.g. non-OBO CURIE prefixes, failed term lookups).",
     )
     return parser
 
@@ -84,7 +90,12 @@ def _resolve_options(args: argparse.Namespace) -> EmitOptions:
     name = args.name or _name_from_filename(args.input)
     class_name = args.class_name or _class_from_name(name)
     schema_id = args.schema_id or f"{DEFAULT_ID_BASE}/{name}"
-    return EmitOptions(schema_id=schema_id, schema_name=name, class_name=class_name)
+    return EmitOptions(
+        schema_id=schema_id,
+        schema_name=name,
+        class_name=class_name,
+        annotate_terms=args.annotate_terms,
+    )
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:

--- a/converter/radx_dd_converter/cli.py
+++ b/converter/radx_dd_converter/cli.py
@@ -92,6 +92,12 @@ def _build_parser() -> argparse.ArgumentParser:
         help="BioPortal API key (overrides the BIOPORTAL_API_KEY env var).",
     )
     parser.add_argument(
+        "--annotate-enum-values",
+        action="store_true",
+        help="After a field enum range, add a comment listing its value=label "
+        "pairs (capped, with a '(+N more)' overflow).",
+    )
+    parser.add_argument(
         "--allow-duplicates",
         action="store_true",
         help="Do not fail on a duplicate Id; keep the first occurrence, skip "
@@ -118,6 +124,7 @@ def _resolve_options(args: argparse.Namespace) -> EmitOptions:
         annotate_terms=args.annotate_terms,
         resolver=args.resolver,
         bioportal_apikey=apikey,
+        annotate_enum_values=args.annotate_enum_values,
     )
 
 

--- a/converter/radx_dd_converter/datatypes.py
+++ b/converter/radx_dd_converter/datatypes.py
@@ -1,0 +1,147 @@
+"""Map RADx / XSD datatype names to LinkML ranges.
+
+A RADx ``Datatype`` value is either a LinkML built-in range (returned directly)
+or a datatype with no LinkML built-in, for which the converter must emit a
+custom ``type`` into the output schema's ``types:`` block so the schema is
+self-contained (see ``linkml/CONVERTER_PLAN.md``).
+
+Datatype names are case-sensitive per the specification; the maps below use
+exact keys. An unknown / mis-cased name is a :class:`UnknownDatatypeError`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Union
+
+# --- Direct mappings: RADx/XSD name -> LinkML built-in range ---------------
+#
+# Grouped by target for readability. Every one of the 47 allowable datatype
+# names is accounted for either here or in CUSTOM_TYPES below.
+
+_STRING_LIKE = (
+    "string",
+    "normalizedString",
+    "token",
+    "language",
+    "Name",
+    "NCName",
+    "NMTOKEN",
+    "NMTOKENS",
+    "QName",
+)
+
+_INTEGER_LIKE = (
+    "integer",
+    "int",
+    "short",
+    "byte",
+    "long",
+    "nonNegativeInteger",
+    "nonPositiveInteger",
+    "negativeInteger",
+    "positiveInteger",
+    "unsignedLong",
+    "unsignedInt",
+    "unsignedShort",
+    "unsignedByte",
+)
+
+BUILTIN_RANGES: Dict[str, str] = {
+    **{name: "string" for name in _STRING_LIKE},
+    **{name: "integer" for name in _INTEGER_LIKE},
+    "decimal": "decimal",
+    "float": "float",
+    "double": "double",
+    "boolean": "boolean",
+    "date": "date",
+    "dateTime": "datetime",
+    "time": "time",
+    "anyURI": "uri",
+}
+
+
+@dataclass(frozen=True)
+class CustomType:
+    """A LinkML custom ``type`` the converter must emit for a datatype.
+
+    ``name`` is both the RADx datatype name and the emitted type name.
+    ``typeof`` is the base LinkML type it derives from. ``pattern`` is an
+    optional lexical constraint. ``uri`` records the type's provenance
+    (typically ``xsd:<name>``) so the emitted type is self-describing.
+    """
+
+    name: str
+    typeof: str
+    pattern: Optional[str] = None
+    uri: Optional[str] = None
+    description: Optional[str] = None
+
+
+# --- Custom types: RADx/XSD name -> CustomType spec ------------------------
+#
+# XSD types with no LinkML built-in, plus the three RADx-specific names. The
+# emitter adds each USED custom type to the output schema's `types:` block.
+
+CUSTOM_TYPES: Dict[str, CustomType] = {
+    # RADx-specific datatypes.
+    "date_mdy": CustomType(
+        "date_mdy",
+        typeof="date",
+        pattern=r"^\d{2}/\d{2}/\d{4}$",
+        description="US-formatted date with slashes (mm/dd/yyyy).",
+    ),
+    "date_dmy": CustomType(
+        "date_dmy",
+        typeof="date",
+        pattern=r"^\d{2}/\d{2}/\d{4}$",
+        description="International-formatted date with slashes (dd/mm/yyyy).",
+    ),
+    "timestamp": CustomType(
+        "timestamp",
+        typeof="integer",
+        pattern=r"^[0-9]+$",
+        description="A long integer representing a Unix timestamp.",
+    ),
+    # XSD gregorian date/time fragments (no LinkML built-in).
+    "gYearMonth": CustomType("gYearMonth", typeof="string", pattern=r"^-?\d{4}-\d{2}(Z|[+-]\d{2}:\d{2})?$", uri="xsd:gYearMonth"),
+    "gYear": CustomType("gYear", typeof="string", pattern=r"^-?\d{4}(Z|[+-]\d{2}:\d{2})?$", uri="xsd:gYear"),
+    "gMonthDay": CustomType("gMonthDay", typeof="string", pattern=r"^--\d{2}-\d{2}(Z|[+-]\d{2}:\d{2})?$", uri="xsd:gMonthDay"),
+    "gDay": CustomType("gDay", typeof="string", pattern=r"^---\d{2}(Z|[+-]\d{2}:\d{2})?$", uri="xsd:gDay"),
+    "gMonth": CustomType("gMonth", typeof="string", pattern=r"^--\d{2}(Z|[+-]\d{2}:\d{2})?$", uri="xsd:gMonth"),
+    # XSD types with no LinkML built-in; kept as string but with xsd provenance.
+    "duration": CustomType("duration", typeof="string", uri="xsd:duration"),
+    "hexBinary": CustomType("hexBinary", typeof="string", pattern=r"^([0-9a-fA-F]{2})*$", uri="xsd:hexBinary"),
+    "base64Binary": CustomType("base64Binary", typeof="string", uri="xsd:base64Binary"),
+    "NOTATION": CustomType("NOTATION", typeof="string", uri="xsd:NOTATION"),
+    "ID": CustomType("ID", typeof="string", uri="xsd:ID"),
+    "IDREF": CustomType("IDREF", typeof="string", uri="xsd:IDREF"),
+    "IDREFS": CustomType("IDREFS", typeof="string", uri="xsd:IDREFS"),
+    "ENTITY": CustomType("ENTITY", typeof="string", uri="xsd:ENTITY"),
+    "ENTITIES": CustomType("ENTITIES", typeof="string", uri="xsd:ENTITIES"),
+}
+
+
+class UnknownDatatypeError(ValueError):
+    """Raised when a Datatype value is not a recognised RADx/XSD datatype name."""
+
+
+def resolve_datatype(name: str) -> Union[str, CustomType]:
+    """Resolve a RADx ``Datatype`` name.
+
+    Returns either a LinkML built-in range name (``str``) that can be used
+    directly as a slot ``range``, or a :class:`CustomType` that the emitter must
+    add to the schema's ``types:`` block (and whose ``name`` is then used as the
+    slot ``range``).
+
+    Raises :class:`UnknownDatatypeError` for an unrecognised or mis-cased name.
+    """
+    if name in BUILTIN_RANGES:
+        return BUILTIN_RANGES[name]
+    if name in CUSTOM_TYPES:
+        return CUSTOM_TYPES[name]
+    raise UnknownDatatypeError(
+        f"Unknown datatype name {name!r}. Datatype names are case-sensitive and "
+        f"must be an XML Schema datatype name or a RADx extension "
+        f"(date_mdy, date_dmy, timestamp)."
+    )

--- a/converter/radx_dd_converter/emit.py
+++ b/converter/radx_dd_converter/emit.py
@@ -174,7 +174,11 @@ class Emitter:
             n, suffix = f"{enum_name}{suffix}", suffix + 1
         enum_name = n
 
-        enum = EnumDefinition(name=enum_name)
+        enum = EnumDefinition(
+            name=enum_name,
+            description="A controlled set of values generated from a data "
+            "dictionary Enumeration cell.",
+        )
         for item in items:
             pv = PermissibleValue(text=item.value, title=item.label or None)
             if item.iri:

--- a/converter/radx_dd_converter/emit.py
+++ b/converter/radx_dd_converter/emit.py
@@ -1,0 +1,313 @@
+"""Emit a LinkML schema from parsed data dictionary rows.
+
+Assembles the ``Row`` objects (from :mod:`reader`) plus the parsed cell
+grammars, datatype resolution, unit lookup and standard missing-value codes into
+a ``linkml_runtime`` :class:`SchemaDefinition`, which is then dumped to YAML.
+Building the object model (rather than templating text) means the output is
+always well-formed. See ``linkml/CONVERTER_PLAN.md`` for the mapping decisions.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from linkml_runtime.dumpers import yaml_dumper
+from linkml_runtime.linkml_model.meta import (
+    AnonymousSlotExpression,
+    ClassDefinition,
+    EnumDefinition,
+    Example,
+    PermissibleValue,
+    SchemaDefinition,
+    SlotDefinition,
+    SubsetDefinition,
+    TypeDefinition,
+    UnitOfMeasure as LinkMLUnitOfMeasure,
+)
+
+from .datatypes import CustomType, resolve_datatype
+from .grammar import EnumItem, parse_enumeration, parse_missing_value_codes, parse_terms
+from .missing_values import (
+    STANDARD_ENUM_NAME,
+    STANDARD_MISSING_VALUE_CODES,
+)
+from .reader import Row
+from .units import lookup_unit
+
+logger = logging.getLogger(__name__)
+
+_URL_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
+_CURIE_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_.-]*):(.+)$")
+_OBO_PURL = "http://purl.obolibrary.org/obo/"
+
+
+def _sanitize(name: str) -> str:
+    """Turn an arbitrary Id/Section into a LinkML-safe name.
+
+    Non-word characters become underscores; a leading digit is prefixed. The
+    original value is preserved elsewhere (slot title / annotation), so this only
+    affects the schema-internal name.
+    """
+    safe = re.sub(r"\W+", "_", name.strip()).strip("_")
+    if not safe:
+        safe = "_"
+    if safe[0].isdigit():
+        safe = f"x_{safe}"
+    return safe
+
+
+def _class_case(name: str) -> str:
+    """CamelCase a name for use as an enum/class name."""
+    parts = re.split(r"\W+", name.strip())
+    return "".join(p[:1].upper() + p[1:] for p in parts if p) or "X"
+
+
+@dataclass
+class EmitOptions:
+    """Options controlling schema identity (from CLI flags / filename)."""
+
+    schema_id: str = "https://w3id.org/radx/generated"
+    schema_name: str = "radx_generated"
+    class_name: str = "Record"
+    default_prefix: Optional[str] = None  # defaults to schema_name
+
+
+class Emitter:
+    """Builds a LinkML SchemaDefinition from data dictionary rows."""
+
+    def __init__(self, options: Optional[EmitOptions] = None):
+        self.opts = options or EmitOptions()
+        self._prefixes: Dict[str, str] = {}
+        self._enum_by_signature: Dict[str, str] = {}  # dedup identical enumerations
+
+    # -- prefixes / term identifiers ---------------------------------------
+
+    def _register_term(self, term: str) -> str:
+        """Register the prefix of a CURIE (OBO auto-expansion); return term as-is.
+
+        Full IRIs are returned unchanged with no registration. OBO-style CURIEs
+        get their prefix auto-registered via the deterministic OBO rule. A
+        non-OBO CURIE whose prefix is unknown is kept and a warning is logged.
+        """
+        term = term.strip()
+        if _URL_RE.match(term):
+            return term  # full IRI; nothing to register
+        m = _CURIE_RE.match(term)
+        if not m:
+            return term  # not a CURIE; leave as-is
+        prefix = m.group(1)
+        if prefix not in self._prefixes:
+            # Auto-register any CURIE prefix using the OBO PURL rule. This is
+            # correct for OBO Foundry ontologies; for a non-OBO prefix it is a
+            # best-effort default, so we warn.
+            self._prefixes[prefix] = f"{_OBO_PURL}{prefix}_"
+            if not _looks_obo(prefix):
+                logger.warning(
+                    "Prefix %r is not a known OBO Foundry id space; registered "
+                    "with a best-effort OBO expansion. Verify or override it.",
+                    prefix,
+                )
+        return term
+
+    # -- enumerations ------------------------------------------------------
+
+    def _emit_enum(self, schema: SchemaDefinition, base_name: str,
+                   items: List[EnumItem]) -> str:
+        """Create (or reuse) an enum for ``items``; return its name."""
+        signature = repr([(i.value, i.label, i.iri) for i in items])
+        if signature in self._enum_by_signature:
+            return self._enum_by_signature[signature]
+
+        enum_name = f"{_class_case(base_name)}Enum"
+        # Avoid name collisions with an existing, differently-valued enum.
+        n, suffix = enum_name, 2
+        while n in schema.enums:
+            n, suffix = f"{enum_name}{suffix}", suffix + 1
+        enum_name = n
+
+        enum = EnumDefinition(name=enum_name)
+        for item in items:
+            pv = PermissibleValue(text=item.value, description=item.label or None)
+            if item.iri:
+                pv.meaning = self._register_term(item.iri)
+            enum.permissible_values[item.value] = pv
+        schema.enums[enum_name] = enum
+        self._enum_by_signature[signature] = enum_name
+        return enum_name
+
+    def _ensure_standard_codes_enum(self, schema: SchemaDefinition) -> None:
+        if STANDARD_ENUM_NAME in schema.enums:
+            return
+        enum = EnumDefinition(
+            name=STANDARD_ENUM_NAME,
+            description="The standard set of RADx missing-value codes, which "
+            "always applies to a missing-value-coded field.",
+        )
+        for item in STANDARD_MISSING_VALUE_CODES:
+            enum.permissible_values[item.value] = PermissibleValue(
+                text=item.value, description=item.label or None
+            )
+        schema.enums[STANDARD_ENUM_NAME] = enum
+
+    # -- per-row slot ------------------------------------------------------
+
+    def _build_slot(self, schema: SchemaDefinition, row: Row) -> SlotDefinition:
+        slot = SlotDefinition(name=_sanitize(row.id))
+
+        # Preserve the original Id if sanitisation changed it.
+        if slot.name != row.id:
+            slot.annotations["original_id"] = row.id
+
+        slot.title = row.get("Label") or None
+        if row.get("Description"):
+            slot.description = row.get("Description")
+        if row.get("Notes"):
+            slot.comments.append(row.get("Notes"))
+        if row.get("SeeAlso"):
+            slot.see_also.append(row.get("SeeAlso"))
+
+        # Aliases (pipe-delimited).
+        for alias in _split_pipe(row.get("Aliases")):
+            slot.aliases.append(alias)
+
+        # Examples (pipe-delimited).
+        for ex in _split_pipe(row.get("Examples")):
+            slot.examples.append(Example(value=ex))
+
+        # Cardinality.
+        if row.get("Cardinality").strip().lower() == "multiple":
+            slot.multivalued = True
+
+        # Pattern (verbatim; XSD-regex dialect).
+        if row.get("Pattern"):
+            slot.pattern = row.get("Pattern")
+
+        # Terms -> slot_uri (first) + exact_mappings (rest). SlotDefinition uses
+        # `slot_uri` (single) and `exact_mappings` (list).
+        terms = parse_terms(row.get("Terms"))
+        if terms:
+            slot.slot_uri = self._register_term(terms[0])
+            for t in terms[1:]:
+                slot.exact_mappings.append(self._register_term(t))
+
+        # Provenance -> source: if URL/CURIE, else annotation.
+        prov = row.get("Provenance").strip()
+        if prov:
+            if _URL_RE.match(prov) or _CURIE_RE.match(prov):
+                slot.source = prov
+            else:
+                slot.annotations["provenance"] = prov
+
+        # Section -> in_subset + declared subset.
+        section = row.get("Section").strip()
+        if section:
+            subset_name = _sanitize(section)
+            if subset_name not in schema.subsets:
+                schema.subsets[subset_name] = SubsetDefinition(
+                    name=subset_name, description=section
+                )
+            slot.in_subset.append(subset_name)
+
+        # Unit -> native unit: (lookup-assisted), raw always preserved.
+        unit_raw = row.get("Unit").strip()
+        if unit_raw:
+            slot.annotations["unit_raw"] = unit_raw
+            known = lookup_unit(unit_raw)
+            if known is not None:
+                slot.unit = LinkMLUnitOfMeasure(
+                    descriptive_name=known.descriptive_name,
+                    symbol=known.symbol,
+                    ucum_code=known.ucum_code,
+                )
+            else:
+                slot.unit = LinkMLUnitOfMeasure(symbol=unit_raw)
+
+        # Range: Enumeration wins over Datatype; missing-value codes augment via any_of.
+        self._apply_range(schema, row, slot)
+        return slot
+
+    def _apply_range(self, schema: SchemaDefinition, row: Row,
+                     slot: SlotDefinition) -> None:
+        enum_items = parse_enumeration(row.get("Enumeration"))
+        field_codes = parse_missing_value_codes(row.get("MissingValueCodes"))
+
+        if enum_items:
+            # Enumeration is the controlling set; underlying datatype preserved.
+            enum_name = self._emit_enum(schema, row.id, enum_items)
+            slot.annotations["value_datatype"] = row.get("Datatype")
+
+            branches = [AnonymousSlotExpression(range=enum_name)]
+            self._ensure_standard_codes_enum(schema)
+            branches.append(AnonymousSlotExpression(range=STANDARD_ENUM_NAME))
+            if field_codes:
+                field_codes_name = self._emit_enum(
+                    schema, f"{row.id}MissingValueCodes", field_codes
+                )
+                branches.append(AnonymousSlotExpression(range=field_codes_name))
+            slot.any_of = branches
+        else:
+            # No enumeration: range from Datatype (builtin or custom type).
+            resolved = resolve_datatype(row.get("Datatype"))
+            if isinstance(resolved, CustomType):
+                self._emit_custom_type(schema, resolved)
+                slot.range = resolved.name
+            else:
+                slot.range = resolved
+
+    def _emit_custom_type(self, schema: SchemaDefinition, ct: CustomType) -> None:
+        if ct.name in schema.types:
+            return
+        schema.types[ct.name] = TypeDefinition(
+            name=ct.name,
+            typeof=ct.typeof,
+            pattern=ct.pattern,
+            uri=ct.uri,
+            description=ct.description,
+        )
+
+    # -- top-level build ---------------------------------------------------
+
+    def build(self, rows: List[Row]) -> SchemaDefinition:
+        opts = self.opts
+        schema = SchemaDefinition(
+            id=opts.schema_id,
+            name=opts.schema_name,
+            default_range="string",
+            default_prefix=opts.default_prefix or opts.schema_name,
+        )
+        schema.imports.append("linkml:types")
+        schema.prefixes["linkml"] = "https://w3id.org/linkml/"
+
+        cls = ClassDefinition(name=opts.class_name, tree_root=True)
+        for row in rows:
+            slot = self._build_slot(schema, row)
+            cls.attributes[slot.name] = slot
+        schema.classes[cls.name] = cls
+
+        # Register any prefixes discovered while building slots.
+        for prefix, expansion in self._prefixes.items():
+            schema.prefixes.setdefault(prefix, expansion)
+
+        return schema
+
+    def dumps(self, rows: List[Row]) -> str:
+        return yaml_dumper.dumps(self.build(rows))
+
+
+def _split_pipe(cell: str) -> List[str]:
+    if not cell or not cell.strip():
+        return []
+    return [part for part in cell.split("|")]
+
+
+def _looks_obo(prefix: str) -> bool:
+    """Heuristic: OBO Foundry id spaces are upper-case alphanumerics."""
+    return bool(re.fullmatch(r"[A-Z][A-Z0-9]+", prefix))
+
+
+def emit_schema(rows: List[Row], options: Optional[EmitOptions] = None) -> str:
+    """Convenience: build and dump a LinkML schema YAML string from rows."""
+    return Emitter(options).dumps(rows)

--- a/converter/radx_dd_converter/emit.py
+++ b/converter/radx_dd_converter/emit.py
@@ -103,6 +103,7 @@ class EmitOptions:
     schema_name: str = "radx_generated"
     class_name: str = "Record"
     default_prefix: Optional[str] = None  # defaults to schema_name
+    annotate_terms: bool = False  # look up ontology term names and add as comments
 
 
 class Emitter:
@@ -112,6 +113,7 @@ class Emitter:
         self.opts = options or EmitOptions()
         self._prefixes: Dict[str, str] = {}
         self._enum_by_signature: Dict[str, str] = {}  # dedup identical enumerations
+        self._terms: set = set()  # every term identifier emitted (for annotation)
 
     # -- prefixes / term identifiers ---------------------------------------
 
@@ -123,6 +125,7 @@ class Emitter:
         non-OBO CURIE whose prefix is unknown is kept and a warning is logged.
         """
         term = term.strip()
+        self._terms.add(term)
         if _URL_RE.match(term):
             return term  # full IRI; nothing to register
         m = _CURIE_RE.match(term)
@@ -336,7 +339,14 @@ class Emitter:
         _drop_redundant_keys(as_dict)
         _order_slot_keys(as_dict)
         _annotations_last(as_dict)
-        return _render(as_dict)
+        text = _render(as_dict)
+        if self.opts.annotate_terms and self._terms:
+            from .terms_lookup import lookup_labels
+
+            labels = lookup_labels(self._terms)
+            if labels:
+                text = _annotate_term_lines(text, labels)
+        return text
 
 
 # Human-readable header comments for the mapping-valued sections, and the
@@ -503,6 +513,26 @@ def _annotations_last(as_dict: dict) -> None:
             if isinstance(slot, dict) and "annotations" in slot:
                 ann = slot.pop("annotations")
                 slot["annotations"] = ann  # re-insert at the end
+
+
+def _annotate_term_lines(text: str, labels: Dict[str, str]) -> str:
+    """Append ``  # <label>`` to YAML lines whose value is a known term.
+
+    Matches only the two shapes in which term identifiers appear: a mapping
+    value (``  meaning: CURIE``) and a list item (``  - CURIE``). The value is
+    compared exactly against the resolved ``labels`` keys, so block-scalar text
+    and unrelated lines are never touched. A line already carrying a comment is
+    left alone.
+    """
+    line_re = re.compile(r"^(\s*(?:-\s+|[\w.]+:\s+))(\S+)\s*$")
+    out: List[str] = []
+    for line in text.split("\n"):
+        m = line_re.match(line)
+        if m and m.group(2) in labels and "#" not in line:
+            out.append(f"{line}  # {labels[m.group(2)]}")
+        else:
+            out.append(line)
+    return "\n".join(out)
 
 
 def _strip_type_keys(obj):

--- a/converter/radx_dd_converter/emit.py
+++ b/converter/radx_dd_converter/emit.py
@@ -445,13 +445,22 @@ def _space_entries_at(text: str, indent: int) -> str:
 _NUMBERED_SECTIONS = {"enums", "subsets", "classes"}
 
 
-def _number_entries_at(section_yaml: str, indent: int, total: int) -> str:
-    """Append `# n of m` to each mapping entry at ``indent`` within a section.
+def _number_entries_at(
+    section_yaml: str, indent: int, total: int, label: str
+) -> str:
+    """Append `# n of m <label>` to each mapping entry at ``indent``.
+
+    ``label`` is the plural type name (e.g. ``"enums"``), suffixed so the
+    counter is self-describing, e.g. ``# 4 of 17 enums`` (singularised when
+    ``total`` is 1, e.g. ``# 1 of 1 class``).
 
     An entry line has exactly ``indent`` leading spaces then a ``key:`` (not a
     list item, not deeper). Block-scalar text and nested keys are left untouched.
     A line already carrying a comment is not doubled.
     """
+    _SINGULAR = {"data elements": "data element", "enums": "enum",
+                 "sections": "section", "classes": "class"}
+    noun = _SINGULAR.get(label, label) if total == 1 else label
     prefix = " " * indent
     out: List[str] = []
     n = 0
@@ -465,7 +474,7 @@ def _number_entries_at(section_yaml: str, indent: int, total: int) -> str:
         )
         if is_entry and "#" not in line:
             n += 1
-            out.append(f"{line}  # {n} of {total}")
+            out.append(f"{line}  # {n} of {total} {noun}")
         else:
             out.append(line)
     return "\n".join(out)
@@ -489,17 +498,20 @@ def _render(as_dict: dict) -> str:
             # Slots live two levels down under `attributes:`; space them there.
             body = _space_entries_at(body, indent=6)
             # Number the class(es) at indent 2 and the slots at indent 6.
-            body = _number_entries_at(body, indent=2, total=len(value or {}))
+            body = _number_entries_at(body, indent=2, total=len(value or {}), label="classes")
             slot_total = sum(
                 len((cls or {}).get("attributes") or {}) for cls in value.values()
             )
-            body = _number_entries_at(body, indent=6, total=slot_total)
+            body = _number_entries_at(
+                body, indent=6, total=slot_total, label="data elements"
+            )
         elif key in _SPACED_SECTIONS:
             body = _space_entries_at(body, indent=2)
 
         # Number the entries of enums / subsets as "n of m" (classes handled above).
         if key in _NUMBERED_SECTIONS and key != "classes":
-            body = _number_entries_at(body, indent=2, total=len(value or {}))
+            label = "sections" if key == "subsets" else key
+            body = _number_entries_at(body, indent=2, total=len(value or {}), label=label)
         blocks.append(f"# --- {comment} ---\n{body}")
 
     header = "\n".join(scalar_header)

--- a/converter/radx_dd_converter/emit.py
+++ b/converter/radx_dd_converter/emit.py
@@ -343,6 +343,23 @@ class Emitter:
         for prefix, expansion in self._prefixes.items():
             schema.prefixes.setdefault(prefix, expansion)
 
+        # Finalise field-enum descriptions now that the full usage map is known:
+        # name the single data element when an enum is used by exactly one,
+        # otherwise keep the generic wording.
+        for enum_name, users in self._enum_users.items():
+            enum = schema.enums.get(enum_name)
+            if enum is None:
+                continue
+            if len(users) == 1:
+                enum.description = (
+                    f"Permissible values for the `{users[0]}` data element."
+                )
+            else:
+                enum.description = (
+                    f"Permissible values shared by {len(users)} data elements "
+                    f"(see the `used by` annotation)."
+                )
+
         return schema
 
     def dumps(self, rows: List[Row]) -> str:

--- a/converter/radx_dd_converter/emit.py
+++ b/converter/radx_dd_converter/emit.py
@@ -108,6 +108,7 @@ class EmitOptions:
     annotate_terms: bool = False  # look up ontology term names and add as comments
     resolver: str = "ols4"  # term-name resolver: "ols4" or "bioportal"
     bioportal_apikey: Optional[str] = None  # required when resolver == "bioportal"
+    annotate_enum_values: bool = False  # comment field-enum values after range:
 
 
 class Emitter:
@@ -118,6 +119,10 @@ class Emitter:
         self._prefixes: Dict[str, str] = {}
         self._enum_by_signature: Dict[str, str] = {}  # dedup identical enumerations
         self._terms: set = set()  # every term identifier emitted (for annotation)
+        # Field enums (from Enumeration cells) mapped to their (value, label)
+        # pairs, for the optional value comment after `range: <Enum>`. Excludes
+        # StandardMissingValueCodes and field-specific missing-code enums.
+        self._field_enum_values: Dict[str, list] = {}
 
     # -- prefixes / term identifiers ---------------------------------------
 
@@ -272,6 +277,9 @@ class Emitter:
         if enum_items:
             # Enumeration is the controlling set; underlying datatype preserved.
             enum_name = self._emit_enum(schema, row.id, enum_items)
+            self._field_enum_values.setdefault(
+                enum_name, [(i.value, i.label) for i in enum_items]
+            )
             slot.annotations["value_datatype"] = row.get("Datatype")
 
             branches = [AnonymousSlotExpression(range=enum_name)]
@@ -354,6 +362,8 @@ class Emitter:
             )
             if labels:
                 text = _annotate_term_lines(text, labels)
+        if self.opts.annotate_enum_values and self._field_enum_values:
+            text = _annotate_enum_ranges(text, self._field_enum_values)
         return text
 
 
@@ -538,6 +548,40 @@ def _annotate_term_lines(text: str, labels: Dict[str, str]) -> str:
         m = line_re.match(line)
         if m and m.group(2) in labels and "#" not in line:
             out.append(f"{line}  # {labels[m.group(2)]}")
+        else:
+            out.append(line)
+    return "\n".join(out)
+
+
+_ENUM_VALUE_CAP = 6  # max value=label pairs shown inline before "(+N more)"
+
+
+def _format_enum_comment(pairs: list) -> str:
+    """Build a capped ``value=label | ...`` comment body for an enum."""
+    shown = pairs[:_ENUM_VALUE_CAP]
+    parts = [f"{v}={label}" if label else f"{v}" for v, label in shown]
+    body = " | ".join(parts)
+    extra = len(pairs) - len(shown)
+    if extra > 0:
+        body += f" (+{extra} more)"
+    return body
+
+
+def _annotate_enum_ranges(text: str, field_enum_values: Dict[str, list]) -> str:
+    """Append a capped value=label comment after ``range: <FieldEnum>`` lines.
+
+    Only enum names present in ``field_enum_values`` are annotated (so the
+    shared StandardMissingValueCodes and field-specific missing-code enums are
+    skipped). Matches both ``range: X`` and ``- range: X`` (the ``any_of``
+    branch). Lines already carrying a comment are left alone.
+    """
+    line_re = re.compile(r"^(\s*(?:-\s+)?range:\s+)(\S+)\s*$")
+    out: List[str] = []
+    for line in text.split("\n"):
+        m = line_re.match(line)
+        if m and m.group(2) in field_enum_values and "#" not in line:
+            comment = _format_enum_comment(field_enum_values[m.group(2)])
+            out.append(f"{line}  # {comment}")
         else:
             out.append(line)
     return "\n".join(out)

--- a/converter/radx_dd_converter/emit.py
+++ b/converter/radx_dd_converter/emit.py
@@ -147,7 +147,6 @@ class EmitOptions:
     resolver: str = "ols4"  # term-name resolver: "ols4" or "bioportal"
     bioportal_apikey: Optional[str] = None  # required when resolver == "bioportal"
     annotate_enum_values: bool = False  # comment field-enum values after range:
-    annotate_enum_usage: bool = False  # comment which data elements use each enum
 
 
 class Emitter:
@@ -485,8 +484,11 @@ class Emitter:
                 text = _annotate_term_lines(text, labels)
         if self.opts.annotate_enum_values and self._field_enum_values:
             text = _annotate_enum_ranges(text, self._field_enum_values)
-        if self.opts.annotate_enum_usage and self._enum_users:
-            text = _annotate_enum_usage(text, self._enum_users)
+        # Field enums get a 3-line comment block above their definition (Enum
+        # n of m / Used by N data elements / the referencing ids). This replaces
+        # the trailing "# n of m enums" counter that _render added for them.
+        if self._enum_users:
+            text = _annotate_enum_blocks(text, self._enum_users)
         return text
 
 
@@ -761,19 +763,25 @@ def _annotate_enum_ranges(text: str, field_enum_values: Dict[str, list]) -> str:
     return "\n".join(out)
 
 
-_ENUM_USERS_CAP = 6  # max data-element ids listed in a "used by" comment
+_ENUM_USERS_CAP = 6  # max data-element ids listed in the "used by" comment line
 
 
-def _annotate_enum_usage(text: str, enum_users: Dict[str, list]) -> str:
-    """Append a capped "used by: <ids>" note to each field enum definition line.
+def _annotate_enum_blocks(text: str, enum_users: Dict[str, list]) -> str:
+    """Put a 3-line comment block above each field enum definition.
 
-    Targets enum *definition* lines (indent 2, ``  EnumName:``) whose name is in
-    ``enum_users`` (so StandardMissingValueCodes and field-code enums are
-    excluded). The enum line may already carry a "# n of m enums" comment from
-    the numbering pass, so the note is appended to any existing comment with a
-    separator rather than skipped.
+    For each field-enum definition line (indent 2, ``  EnumName:``) whose name
+    is in ``enum_users``, the trailing ``# n of m enums`` counter that _render
+    added is moved into a block above the enum::
+
+        # Enum n of m
+        # Used by N data elements
+        # id1 | id2 | ... (+K more)
+        EnumName:
+
+    StandardMissingValueCodes and field-code enums are not in ``enum_users`` and
+    keep their plain trailing counter untouched.
     """
-    line_re = re.compile(r"^ {2}(\S+):(\s*#.*)?$")
+    line_re = re.compile(r"^ {2}(\S+):\s*(#\s*(\d+) of (\d+) enums?)?\s*$")
     out: List[str] = []
     for line in text.split("\n"):
         m = line_re.match(line)
@@ -781,16 +789,17 @@ def _annotate_enum_usage(text: str, enum_users: Dict[str, list]) -> str:
         if name in enum_users:
             users = enum_users[name]
             shown = users[:_ENUM_USERS_CAP]
-            body = " | ".join(shown)
+            id_list = " | ".join(shown)
             extra = len(users) - len(shown)
             if extra > 0:
-                body += f" (+{extra} more)"
-            note = f"used by: {body}"
-            existing = (m.group(2) or "").strip()
-            if existing:  # already has "# n of m enums"
-                out.append(f"  {name}:{m.group(2).rstrip()}; {note}")
-            else:
-                out.append(f"  {name}:  # {note}")
+                id_list += f" (+{extra} more)"
+            n, total = m.group(3), m.group(4)
+            de = "data element" if len(users) == 1 else "data elements"
+            if n and total:
+                out.append(f"  # Enum {n} of {total}")
+            out.append(f"  # Used by {len(users)} {de}")
+            out.append(f"  # {id_list}")
+            out.append(f"  {name}:")  # bare key line (trailing comment removed)
         else:
             out.append(line)
     return "\n".join(out)

--- a/converter/radx_dd_converter/emit.py
+++ b/converter/radx_dd_converter/emit.py
@@ -104,6 +104,8 @@ class EmitOptions:
     class_name: str = "Record"
     default_prefix: Optional[str] = None  # defaults to schema_name
     annotate_terms: bool = False  # look up ontology term names and add as comments
+    resolver: str = "ols4"  # term-name resolver: "ols4" or "bioportal"
+    bioportal_apikey: Optional[str] = None  # required when resolver == "bioportal"
 
 
 class Emitter:
@@ -343,7 +345,11 @@ class Emitter:
         if self.opts.annotate_terms and self._terms:
             from .terms_lookup import lookup_labels
 
-            labels = lookup_labels(self._terms)
+            labels = lookup_labels(
+                self._terms,
+                resolver=self.opts.resolver,
+                apikey=self.opts.bioportal_apikey,
+            )
             if labels:
                 text = _annotate_term_lines(text, labels)
         return text

--- a/converter/radx_dd_converter/emit.py
+++ b/converter/radx_dd_converter/emit.py
@@ -97,6 +97,44 @@ def _class_case(name: str) -> str:
     return "".join(p[:1].upper() + p[1:] for p in parts if p) or "X"
 
 
+# Value-derived enum names are built from the first few values; when there are
+# more, an "Etc" marker is appended so the name stays short and does not imply a
+# single owning data element. A name longer than this after that is rejected
+# (fall back to the field-derived name).
+_ENUM_NAME_LEAD_VALUES = 3
+_ENUM_NAME_MAX_LEN = 48
+
+
+def _value_derived_enum_name(items: List["EnumItem"]) -> Optional[str]:
+    """Build an enum name from its values, e.g. ``NoYesEnum`` or ``NoYesEtcEnum``.
+
+    Uses the first few values' labels (falling back to the value itself),
+    CamelCased and concatenated in source order; appends ``Etc`` when there are
+    further values, so a value set shared by many data elements gets a short,
+    ownership-neutral name rather than being named after one field. Returns
+    ``None`` only when the leading values yield no usable text, so the caller
+    can fall back to a field-derived name.
+    """
+    if not items:
+        return None
+    lead = items[:_ENUM_NAME_LEAD_VALUES]
+    parts = [_class_case(item.label or item.value) for item in lead]
+    parts = [p for p in parts if p != "X"]  # drop values that sanitise to nothing
+    if not parts:
+        return None
+    name = "".join(parts) + ("Etc" if len(items) > len(lead) else "") + "Enum"
+    if len(name) > _ENUM_NAME_MAX_LEN:
+        return None
+    # Reject digit-heavy names: numeric-range value sets (labels like "100-150")
+    # CamelCase into an illegible digit mash, so fall back to the field name.
+    # Threshold: digits make up more than a quarter of the name.
+    if sum(c.isdigit() for c in name) * 4 > len(name):
+        return None
+    if name[0].isdigit():
+        name = f"X{name}"
+    return name
+
+
 @dataclass
 class EmitOptions:
     """Options controlling schema identity (from CLI flags / filename)."""
@@ -162,12 +200,19 @@ class Emitter:
 
     def _emit_enum(self, schema: SchemaDefinition, base_name: str,
                    items: List[EnumItem]) -> str:
-        """Create (or reuse) an enum for ``items``; return its name."""
+        """Create (or reuse) an enum for ``items``; return its name.
+
+        The enum is named after its *values* (e.g. ``NoYesEnum``) rather than the
+        data element that first used it, since a deduplicated enum may be shared
+        by many data elements and a field-derived name would misleadingly imply
+        a single owner. Falls back to the field-derived name when the values do
+        not yield a usable name.
+        """
         signature = repr([(i.value, i.label, i.iri) for i in items])
         if signature in self._enum_by_signature:
             return self._enum_by_signature[signature]
 
-        enum_name = f"{_class_case(base_name)}Enum"
+        enum_name = _value_derived_enum_name(items) or f"{_class_case(base_name)}Enum"
         # Avoid name collisions with an existing, differently-valued enum.
         n, suffix = enum_name, 2
         while n in schema.enums:

--- a/converter/radx_dd_converter/emit.py
+++ b/converter/radx_dd_converter/emit.py
@@ -164,6 +164,9 @@ class Emitter:
         # Field enum name -> list of slot names that use it (for the optional
         # "used by" reverse-reference comment on the enum definition).
         self._enum_users: Dict[str, list] = {}
+        # Subset (Section) name -> list of slot names in it (for the section
+        # comment block above each subset definition).
+        self._section_users: Dict[str, list] = {}
 
     # -- prefixes / term identifiers ---------------------------------------
 
@@ -302,6 +305,7 @@ class Emitter:
                     name=subset_name, title=section
                 )
             slot.in_subset.append(subset_name)
+            self._section_users.setdefault(subset_name, []).append(slot.name)
 
         # Unit -> native unit: (lookup-assisted), raw always preserved.
         unit_raw = row.get("Unit").strip()
@@ -417,6 +421,17 @@ class Emitter:
         if renames:
             self._apply_enum_renames(schema, renames)
 
+        # Always place the shared StandardMissingValueCodes enum last by
+        # rebuilding the enums mapping in the desired order. schema.enums may be
+        # a plain dict or a linkml JsonObj, so iterate via jsonasobj2.
+        import jsonasobj2
+
+        pairs = list(jsonasobj2.items(schema.enums))
+        if any(name == STANDARD_ENUM_NAME for name, _ in pairs):
+            reordered = {n: e for n, e in pairs if n != STANDARD_ENUM_NAME}
+            reordered[STANDARD_ENUM_NAME] = dict(pairs)[STANDARD_ENUM_NAME]
+            schema.enums = reordered
+
         return schema
 
     def _apply_enum_renames(
@@ -431,8 +446,10 @@ class Emitter:
         # Rebuild the enums mapping preserving order, with renamed keys. Keep the
         # enum's own `name` in sync with its key, else validation rejects the
         # mismatch (and _drop_redundant_keys only strips `name` when it matches).
+        import jsonasobj2
+
         new_enums = {}
-        for name, enum in schema.enums.items():
+        for name, enum in jsonasobj2.items(schema.enums):
             new_name = renames.get(name, name)
             enum.name = new_name
             new_enums[new_name] = enum
@@ -484,11 +501,17 @@ class Emitter:
                 text = _annotate_term_lines(text, labels)
         if self.opts.annotate_enum_values and self._field_enum_values:
             text = _annotate_enum_ranges(text, self._field_enum_values)
-        # Field enums get a 3-line comment block above their definition (Enum
-        # n of m / Used by N data elements / the referencing ids). This replaces
-        # the trailing "# n of m enums" counter that _render added for them.
+        # Move the trailing "n of m" counters into comment blocks above each
+        # entry: field enums and sections get a 3-line block (number / used-by
+        # count / referencing ids); data elements get a 1-line block. This
+        # replaces the trailing counters _render added for them.
         if self._enum_users:
-            text = _annotate_enum_blocks(text, self._enum_users)
+            text = _annotate_blocks(text, 2, "Enum", "enums", self._enum_users)
+        if self._section_users:
+            text = _annotate_blocks(
+                text, 2, "Section", "sections", self._section_users
+            )
+        text = _annotate_blocks(text, 6, "Data element", "data elements")
         return text
 
 
@@ -766,40 +789,54 @@ def _annotate_enum_ranges(text: str, field_enum_values: Dict[str, list]) -> str:
 _ENUM_USERS_CAP = 6  # max data-element ids listed in the "used by" comment line
 
 
-def _annotate_enum_blocks(text: str, enum_users: Dict[str, list]) -> str:
-    """Put a 3-line comment block above each field enum definition.
+def _annotate_blocks(
+    text: str,
+    indent: int,
+    kind: str,
+    counter_noun: str,
+    users: Optional[Dict[str, list]] = None,
+) -> str:
+    """Move an entry's trailing "n of m <noun>" counter into a block above it.
 
-    For each field-enum definition line (indent 2, ``  EnumName:``) whose name
-    is in ``enum_users``, the trailing ``# n of m enums`` counter that _render
-    added is moved into a block above the enum::
+    Matches entry lines at ``indent`` that carry a trailing ``# n of m
+    <counter_noun>`` comment (as emitted by ``_render``). The counter becomes a
+    ``# <kind> n of m`` line above the now-bare key line. When ``users`` is
+    given and contains the entry, two further lines are added — a "Used by N
+    data elements" count and a capped id list — mirroring the enum/section block.
 
-        # Enum n of m
-        # Used by N data elements
-        # id1 | id2 | ... (+K more)
-        EnumName:
-
-    StandardMissingValueCodes and field-code enums are not in ``enum_users`` and
-    keep their plain trailing counter untouched.
+    ``users`` also acts as a filter when provided: only entries present in it are
+    rewritten (others keep their trailing counter). When ``users`` is ``None``
+    every matching entry is rewritten (used for data elements, which have no
+    "used by").
     """
-    line_re = re.compile(r"^ {2}(\S+):\s*(#\s*(\d+) of (\d+) enums?)?\s*$")
+    pad = " " * indent
+    # Match the counter noun in either plural or singular form (_render
+    # singularises when the total is 1), e.g. "enums"/"enum",
+    # "data elements"/"data element".
+    plural = re.escape(counter_noun)
+    singular = re.escape(counter_noun[:-1] if counter_noun.endswith("s") else counter_noun)
+    line_re = re.compile(
+        rf"^{pad}(\S+):\s*(#\s*(\d+) of (\d+) (?:{plural}|{singular}))?\s*$"
+    )
     out: List[str] = []
     for line in text.split("\n"):
         m = line_re.match(line)
         name = m.group(1) if m else None
-        if name in enum_users:
-            users = enum_users[name]
-            shown = users[:_ENUM_USERS_CAP]
-            id_list = " | ".join(shown)
-            extra = len(users) - len(shown)
-            if extra > 0:
-                id_list += f" (+{extra} more)"
+        rewrite = m and (users is None or name in users) and m.group(2)
+        if rewrite:
             n, total = m.group(3), m.group(4)
-            de = "data element" if len(users) == 1 else "data elements"
-            if n and total:
-                out.append(f"  # Enum {n} of {total}")
-            out.append(f"  # Used by {len(users)} {de}")
-            out.append(f"  # {id_list}")
-            out.append(f"  {name}:")  # bare key line (trailing comment removed)
+            out.append(f"{pad}# {kind} {n} of {total}")
+            if users is not None and name in users:
+                who = users[name]
+                shown = who[:_ENUM_USERS_CAP]
+                id_list = " | ".join(shown)
+                extra = len(who) - len(shown)
+                if extra > 0:
+                    id_list += f" (+{extra} more)"
+                de = "data element" if len(who) == 1 else "data elements"
+                out.append(f"{pad}# Used by {len(who)} {de}")
+                out.append(f"{pad}# {id_list}")
+            out.append(f"{pad}{name}:")  # bare key line
         else:
             out.append(line)
     return "\n".join(out)

--- a/converter/radx_dd_converter/emit.py
+++ b/converter/radx_dd_converter/emit.py
@@ -9,12 +9,14 @@ always well-formed. See ``linkml/CONVERTER_PLAN.md`` for the mapping decisions.
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
-from linkml_runtime.dumpers import yaml_dumper
+import yaml
+from linkml_runtime.dumpers import json_dumper
 from linkml_runtime.linkml_model.meta import (
     AnonymousSlotExpression,
     ClassDefinition,
@@ -42,6 +44,30 @@ logger = logging.getLogger(__name__)
 _URL_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
 _CURIE_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_.-]*):(.+)$")
 _OBO_PURL = "http://purl.obolibrary.org/obo/"
+
+
+def _clean_text(text: str) -> str:
+    """Tidy a free-text field for readable YAML output.
+
+    Strips trailing whitespace from each line. Trailing spaces carry no meaning
+    but prevent YAML from using the readable literal-block (`|`) style, forcing
+    the escaped double-quoted form instead. Newlines and internal spacing are
+    preserved, so this is a lossless-in-intent normalisation.
+    """
+    return "\n".join(line.rstrip() for line in text.split("\n"))
+
+
+class _BlockStyleDumper(yaml.SafeDumper):
+    """A YAML dumper that renders multi-line strings as literal `|` blocks."""
+
+
+def _represent_str(dumper: yaml.SafeDumper, data: str):
+    if "\n" in data:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+_BlockStyleDumper.add_representer(str, _represent_str)
 
 
 def _sanitize(name: str) -> str:
@@ -163,9 +189,9 @@ class Emitter:
 
         slot.title = row.get("Label") or None
         if row.get("Description"):
-            slot.description = row.get("Description")
+            slot.description = _clean_text(row.get("Description"))
         if row.get("Notes"):
-            slot.comments.append(row.get("Notes"))
+            slot.comments.append(_clean_text(row.get("Notes")))
         if row.get("SeeAlso"):
             slot.see_also.append(row.get("SeeAlso"))
 
@@ -294,7 +320,36 @@ class Emitter:
         return schema
 
     def dumps(self, rows: List[Row]) -> str:
-        return yaml_dumper.dumps(self.build(rows))
+        """Build the schema and dump it as YAML with readable block strings.
+
+        The schema object is converted to a plain dict via ``json_dumper``
+        (which drops empty/None fields), then dumped with a PyYAML dumper that
+        renders multi-line strings as literal `|` blocks rather than the escaped
+        double-quoted form LinkML's default dumper produces.
+        """
+        schema = self.build(rows)
+        as_dict = _strip_type_keys(json.loads(json_dumper.dumps(schema)))
+        return yaml.dump(
+            as_dict,
+            Dumper=_BlockStyleDumper,
+            sort_keys=False,
+            allow_unicode=True,
+            default_flow_style=False,
+            width=88,
+        )
+
+
+def _strip_type_keys(obj):
+    """Remove JSON-LD ``@type`` keys that json_dumper adds.
+
+    The LinkML schema meta-model rejects an ``@type`` property on the schema
+    object, so it must not appear in the YAML we emit.
+    """
+    if isinstance(obj, dict):
+        return {k: _strip_type_keys(v) for k, v in obj.items() if k != "@type"}
+    if isinstance(obj, list):
+        return [_strip_type_keys(v) for v in obj]
+    return obj
 
 
 def _split_pipe(cell: str) -> List[str]:

--- a/converter/radx_dd_converter/emit.py
+++ b/converter/radx_dd_converter/emit.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 import yaml

--- a/converter/radx_dd_converter/emit.py
+++ b/converter/radx_dd_converter/emit.py
@@ -109,6 +109,7 @@ class EmitOptions:
     resolver: str = "ols4"  # term-name resolver: "ols4" or "bioportal"
     bioportal_apikey: Optional[str] = None  # required when resolver == "bioportal"
     annotate_enum_values: bool = False  # comment field-enum values after range:
+    annotate_enum_usage: bool = False  # comment which data elements use each enum
 
 
 class Emitter:
@@ -123,6 +124,9 @@ class Emitter:
         # pairs, for the optional value comment after `range: <Enum>`. Excludes
         # StandardMissingValueCodes and field-specific missing-code enums.
         self._field_enum_values: Dict[str, list] = {}
+        # Field enum name -> list of slot names that use it (for the optional
+        # "used by" reverse-reference comment on the enum definition).
+        self._enum_users: Dict[str, list] = {}
 
     # -- prefixes / term identifiers ---------------------------------------
 
@@ -280,6 +284,7 @@ class Emitter:
             self._field_enum_values.setdefault(
                 enum_name, [(i.value, i.label) for i in enum_items]
             )
+            self._enum_users.setdefault(enum_name, []).append(slot.name)
             slot.annotations["value_datatype"] = row.get("Datatype")
 
             branches = [AnonymousSlotExpression(range=enum_name)]
@@ -364,6 +369,8 @@ class Emitter:
                 text = _annotate_term_lines(text, labels)
         if self.opts.annotate_enum_values and self._field_enum_values:
             text = _annotate_enum_ranges(text, self._field_enum_values)
+        if self.opts.annotate_enum_usage and self._enum_users:
+            text = _annotate_enum_usage(text, self._enum_users)
         return text
 
 
@@ -633,6 +640,41 @@ def _annotate_enum_ranges(text: str, field_enum_values: Dict[str, list]) -> str:
         if m and m.group(2) in field_enum_values and "#" not in line:
             comment = _format_enum_comment(field_enum_values[m.group(2)])
             out.append(f"{line}  # {comment}")
+        else:
+            out.append(line)
+    return "\n".join(out)
+
+
+_ENUM_USERS_CAP = 6  # max data-element ids listed in a "used by" comment
+
+
+def _annotate_enum_usage(text: str, enum_users: Dict[str, list]) -> str:
+    """Append a capped "used by: <ids>" note to each field enum definition line.
+
+    Targets enum *definition* lines (indent 2, ``  EnumName:``) whose name is in
+    ``enum_users`` (so StandardMissingValueCodes and field-code enums are
+    excluded). The enum line may already carry a "# n of m enums" comment from
+    the numbering pass, so the note is appended to any existing comment with a
+    separator rather than skipped.
+    """
+    line_re = re.compile(r"^ {2}(\S+):(\s*#.*)?$")
+    out: List[str] = []
+    for line in text.split("\n"):
+        m = line_re.match(line)
+        name = m.group(1) if m else None
+        if name in enum_users:
+            users = enum_users[name]
+            shown = users[:_ENUM_USERS_CAP]
+            body = " | ".join(shown)
+            extra = len(users) - len(shown)
+            if extra > 0:
+                body += f" (+{extra} more)"
+            note = f"used by: {body}"
+            existing = (m.group(2) or "").strip()
+            if existing:  # already has "# n of m enums"
+                out.append(f"  {name}:{m.group(2).rstrip()}; {note}")
+            else:
+                out.append(f"  {name}:  # {note}")
         else:
             out.append(line)
     return "\n".join(out)

--- a/converter/radx_dd_converter/emit.py
+++ b/converter/radx_dd_converter/emit.py
@@ -49,12 +49,14 @@ _OBO_PURL = "http://purl.obolibrary.org/obo/"
 def _clean_text(text: str) -> str:
     """Tidy a free-text field for readable YAML output.
 
-    Strips trailing whitespace from each line. Trailing spaces carry no meaning
-    but prevent YAML from using the readable literal-block (`|`) style, forcing
-    the escaped double-quoted form instead. Newlines and internal spacing are
+    Strips trailing whitespace from each line, and strips leading/trailing blank
+    lines from the whole field. Trailing spaces prevent YAML from using the
+    readable literal-block (`|`) style, and trailing blank lines leave a run of
+    empty lines at the end of a block scalar. Internal newlines and spacing are
     preserved, so this is a lossless-in-intent normalisation.
     """
-    return "\n".join(line.rstrip() for line in text.split("\n"))
+    per_line = "\n".join(line.rstrip() for line in text.split("\n"))
+    return per_line.strip("\n")
 
 
 class _BlockStyleDumper(yaml.SafeDumper):

--- a/converter/radx_dd_converter/emit.py
+++ b/converter/radx_dd_converter/emit.py
@@ -86,8 +86,12 @@ def _sanitize(name: str) -> str:
 
 
 def _class_case(name: str) -> str:
-    """CamelCase a name for use as an enum/class name."""
-    parts = re.split(r"\W+", name.strip())
+    """CamelCase a name for use as an enum/class name.
+
+    Splits on any non-alphanumeric character, including underscores, so
+    ``nih_race`` -> ``NihRace`` (not ``Nih_race``).
+    """
+    parts = re.split(r"[^A-Za-z0-9]+", name.strip())
     return "".join(p[:1].upper() + p[1:] for p in parts if p) or "X"
 
 
@@ -156,7 +160,7 @@ class Emitter:
 
         enum = EnumDefinition(name=enum_name)
         for item in items:
-            pv = PermissibleValue(text=item.value, description=item.label or None)
+            pv = PermissibleValue(text=item.value, title=item.label or None)
             if item.iri:
                 pv.meaning = self._register_term(item.iri)
             enum.permissible_values[item.value] = pv
@@ -174,7 +178,7 @@ class Emitter:
         )
         for item in STANDARD_MISSING_VALUE_CODES:
             enum.permissible_values[item.value] = PermissibleValue(
-                text=item.value, description=item.label or None
+                text=item.value, title=item.label or None
             )
         schema.enums[STANDARD_ENUM_NAME] = enum
 
@@ -211,13 +215,11 @@ class Emitter:
         if row.get("Pattern"):
             slot.pattern = row.get("Pattern")
 
-        # Terms -> slot_uri (first) + exact_mappings (rest). SlotDefinition uses
-        # `slot_uri` (single) and `exact_mappings` (list).
-        terms = parse_terms(row.get("Terms"))
-        if terms:
-            slot.slot_uri = self._register_term(terms[0])
-            for t in terms[1:]:
-                slot.exact_mappings.append(self._register_term(t))
+        # Terms -> related_mappings. RADx Terms are subject-matter annotations
+        # (the concept a field relates to), not the slot's predicate URI, so
+        # they map to related_mappings rather than slot_uri / exact_mappings.
+        for term in parse_terms(row.get("Terms")):
+            slot.related_mappings.append(self._register_term(term))
 
         # Provenance -> source: if URL/CURIE, else annotation.
         prov = row.get("Provenance").strip()
@@ -233,7 +235,7 @@ class Emitter:
             subset_name = _sanitize(section)
             if subset_name not in schema.subsets:
                 schema.subsets[subset_name] = SubsetDefinition(
-                    name=subset_name, description=section
+                    name=subset_name, title=section
                 )
             slot.in_subset.append(subset_name)
 
@@ -331,6 +333,9 @@ class Emitter:
         """
         schema = self.build(rows)
         as_dict = _strip_type_keys(json.loads(json_dumper.dumps(schema)))
+        _drop_redundant_keys(as_dict)
+        _order_slot_keys(as_dict)
+        _annotations_last(as_dict)
         return _render(as_dict)
 
 
@@ -345,6 +350,29 @@ _SECTION_COMMENTS = {
 }
 # Sections whose direct entries should be separated by a blank line.
 _SPACED_SECTIONS = {"subsets", "types", "enums", "classes"}
+
+# Orientation header prepended to every generated schema.
+_HEADER_COMMENT = """\
+# LinkML schema generated from a RADx data dictionary by radx-dd-to-linkml.
+#
+# The single class below (the tree_root) describes a target datafile: each of
+# its slots corresponds to one field (column) of that datafile, in order. The
+# non-obvious conventions used here are:
+#
+#   * A field with an enumeration becomes a slot whose value must be one of the
+#     generated <Field>Enum values OR a StandardMissingValueCodes code (and any
+#     field-specific codes) -- expressed with `any_of`. The field's underlying
+#     datatype is kept in the `value_datatype` annotation.
+#   * A field's Section becomes a declared `subset`, referenced from the slot
+#     via `in_subset`.
+#   * Ontology terms are kept as CURIEs; their prefixes are declared in
+#     `prefixes` (OBO id spaces expand under purl.obolibrary.org).
+#   * Machine-oriented annotations (`unit_raw`, `value_datatype`, `provenance`,
+#     `original_id`) appear at the end of each slot.
+#
+# See the RADx Data Dictionary Specification for the source field definitions:
+# https://github.com/bmir-radx/radx-data-dictionary-specification
+"""
 
 
 def _dump_yaml(obj) -> str:
@@ -408,7 +436,73 @@ def _render(as_dict: dict) -> str:
         blocks.append(f"# --- {comment} ---\n{body}")
 
     header = "\n".join(scalar_header)
-    return "\n\n".join([header, *blocks]) + "\n"
+    return _HEADER_COMMENT + "\n" + "\n\n".join([header, *blocks]) + "\n"
+
+
+def _drop_redundant_keys(as_dict: dict) -> None:
+    """Drop identifier keys that merely repeat their mapping key.
+
+    Every element defined as an entry in a mapping (``enums``, ``classes``,
+    ``slots``, ``types``, ``subsets``) is named by its key, so an inner
+    ``name:`` equal to that key is redundant. Likewise a permissible value's
+    ``text:`` equal to its key. LinkML infers both from the key, so removing
+    them is lossless and de-clutters the output. Mutates ``as_dict`` in place.
+    """
+    def strip_named(mapping):
+        """Drop `name:` from any entry whose name equals its key."""
+        for key, element in (mapping or {}).items():
+            if isinstance(element, dict) and element.get("name") == key:
+                del element["name"]
+
+    # Top-level named sections: types, subsets (Sections), slots, enums.
+    for section in ("types", "subsets", "slots", "enums"):
+        strip_named(as_dict.get(section, {}))
+
+    # Permissible values: drop `text:` when it equals the value key.
+    for enum in (as_dict.get("enums") or {}).values():
+        for pv_key, pv in (enum.get("permissible_values") or {}).items():
+            if isinstance(pv, dict) and pv.get("text") == pv_key:
+                del pv["text"]
+
+    # Classes, and their nested slots (attributes).
+    strip_named(as_dict.get("classes", {}))
+    for cls in (as_dict.get("classes") or {}).values():
+        strip_named(cls.get("attributes", {}))
+
+
+# Preferred leading key order for a slot definition. Keys not listed keep their
+# existing relative order after these; `annotations` is forced last separately.
+_SLOT_KEY_ORDER = ("title", "description", "range")
+
+
+def _order_slot_keys(as_dict: dict) -> None:
+    """Reorder each slot's keys so title, description, range come first.
+
+    Remaining keys keep their existing order. Mutates ``as_dict`` in place.
+    """
+    for cls in (as_dict.get("classes") or {}).values():
+        attrs = cls.get("attributes") or {}
+        for slot_name, slot in list(attrs.items()):
+            if not isinstance(slot, dict):
+                continue
+            front = [k for k in _SLOT_KEY_ORDER if k in slot]
+            rest = [k for k in slot if k not in _SLOT_KEY_ORDER]
+            attrs[slot_name] = {k: slot[k] for k in (*front, *rest)}
+
+
+def _annotations_last(as_dict: dict) -> None:
+    """Reorder each slot mapping so ``annotations`` is its last key.
+
+    LinkML emits ``annotations`` near the top of a slot; moving it to the end
+    keeps the human-relevant fields (description, range, ...) first and groups
+    the machine-oriented annotations (``unit_raw``, ``value_datatype``,
+    ``provenance``, ``original_id``) at the bottom. Mutates ``as_dict`` in place.
+    """
+    for cls in as_dict.get("classes", {}).values():
+        for slot_name, slot in list(cls.get("attributes", {}).items()):
+            if isinstance(slot, dict) and "annotations" in slot:
+                ann = slot.pop("annotations")
+                slot["annotations"] = ann  # re-insert at the end
 
 
 def _strip_type_keys(obj):

--- a/converter/radx_dd_converter/emit.py
+++ b/converter/radx_dd_converter/emit.py
@@ -441,6 +441,36 @@ def _space_entries_at(text: str, indent: int) -> str:
     return "\n".join(out)
 
 
+# Sections whose direct entries are numbered "n of m" as a trailing comment.
+_NUMBERED_SECTIONS = {"enums", "subsets", "classes"}
+
+
+def _number_entries_at(section_yaml: str, indent: int, total: int) -> str:
+    """Append `# n of m` to each mapping entry at ``indent`` within a section.
+
+    An entry line has exactly ``indent`` leading spaces then a ``key:`` (not a
+    list item, not deeper). Block-scalar text and nested keys are left untouched.
+    A line already carrying a comment is not doubled.
+    """
+    prefix = " " * indent
+    out: List[str] = []
+    n = 0
+    for line in section_yaml.split("\n"):
+        stripped = line[indent:] if line.startswith(prefix) else ""
+        is_entry = (
+            line.startswith(prefix)
+            and bool(stripped)
+            and not stripped[0].isspace()
+            and not stripped.startswith("-")
+        )
+        if is_entry and "#" not in line:
+            n += 1
+            out.append(f"{line}  # {n} of {total}")
+        else:
+            out.append(line)
+    return "\n".join(out)
+
+
 def _render(as_dict: dict) -> str:
     """Render the schema dict to YAML with section comments and blank lines."""
     scalar_header: List[str] = []
@@ -454,13 +484,22 @@ def _render(as_dict: dict) -> str:
             continue
 
         comment = _SECTION_COMMENTS[key]
+        body = _dump_yaml({key: value}).rstrip("\n")
         if key == "classes":
             # Slots live two levels down under `attributes:`; space them there.
-            body = _space_entries_at(_dump_yaml({key: value}).rstrip("\n"), indent=6)
+            body = _space_entries_at(body, indent=6)
+            # Number the class(es) at indent 2 and the slots at indent 6.
+            body = _number_entries_at(body, indent=2, total=len(value or {}))
+            slot_total = sum(
+                len((cls or {}).get("attributes") or {}) for cls in value.values()
+            )
+            body = _number_entries_at(body, indent=6, total=slot_total)
         elif key in _SPACED_SECTIONS:
-            body = _space_entries_at(_dump_yaml({key: value}).rstrip("\n"), indent=2)
-        else:
-            body = _dump_yaml({key: value}).rstrip("\n")
+            body = _space_entries_at(body, indent=2)
+
+        # Number the entries of enums / subsets as "n of m" (classes handled above).
+        if key in _NUMBERED_SECTIONS and key != "classes":
+            body = _number_entries_at(body, indent=2, total=len(value or {}))
         blocks.append(f"# --- {comment} ---\n{body}")
 
     header = "\n".join(scalar_header)

--- a/converter/radx_dd_converter/emit.py
+++ b/converter/radx_dd_converter/emit.py
@@ -320,23 +320,95 @@ class Emitter:
         return schema
 
     def dumps(self, rows: List[Row]) -> str:
-        """Build the schema and dump it as YAML with readable block strings.
+        """Build the schema and dump it as readable YAML.
 
         The schema object is converted to a plain dict via ``json_dumper``
         (which drops empty/None fields), then dumped with a PyYAML dumper that
-        renders multi-line strings as literal `|` blocks rather than the escaped
-        double-quoted form LinkML's default dumper produces.
+        renders multi-line strings as literal `|` blocks. Section-header
+        comments and blank lines are added between top-level sections and
+        between the entries within the mapping-valued sections (subsets, enums,
+        types, classes), to make the output easier to scan.
         """
         schema = self.build(rows)
         as_dict = _strip_type_keys(json.loads(json_dumper.dumps(schema)))
-        return yaml.dump(
-            as_dict,
-            Dumper=_BlockStyleDumper,
-            sort_keys=False,
-            allow_unicode=True,
-            default_flow_style=False,
-            width=88,
+        return _render(as_dict)
+
+
+# Human-readable header comments for the mapping-valued sections, and the
+# order in which top-level sections are emitted.
+_SECTION_COMMENTS = {
+    "subsets": "Subsets (from the data dictionary's Section column)",
+    "types": "Custom datatypes",
+    "enums": "Enumerations",
+    "slots": "Slots",
+    "classes": "Classes",
+}
+# Sections whose direct entries should be separated by a blank line.
+_SPACED_SECTIONS = {"subsets", "types", "enums", "classes"}
+
+
+def _dump_yaml(obj) -> str:
+    return yaml.dump(
+        obj,
+        Dumper=_BlockStyleDumper,
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+        width=88,
+    )
+
+
+def _space_entries_at(text: str, indent: int) -> str:
+    """Insert a blank line before each mapping entry at the given indent.
+
+    An "entry" line has exactly ``indent`` leading spaces followed by a
+    non-space, non-``-`` character (i.e. a ``key:``). Lines that are more deeply
+    indented, are list items, or are block-scalar text start differently and are
+    left untouched, so multi-line descriptions are preserved verbatim.
+    """
+    prefix = " " * indent
+    out: List[str] = []
+    seen_first = False
+    for line in text.split("\n"):
+        stripped = line[indent:] if line.startswith(prefix) else ""
+        is_entry = (
+            line.startswith(prefix)
+            and bool(stripped)
+            and not stripped[0].isspace()
+            and not stripped.startswith("-")
         )
+        if is_entry:
+            if seen_first:
+                out.append("")
+            seen_first = True
+        out.append(line)
+    return "\n".join(out)
+
+
+def _render(as_dict: dict) -> str:
+    """Render the schema dict to YAML with section comments and blank lines."""
+    scalar_header: List[str] = []
+    blocks: List[str] = []
+
+    for key, value in as_dict.items():
+        # Group the leading scalar/simple header keys together (no blank lines
+        # between them, no section comment): name, id, imports, prefixes, etc.
+        if key not in _SECTION_COMMENTS:
+            scalar_header.append(_dump_yaml({key: value}).rstrip("\n"))
+            continue
+
+        comment = _SECTION_COMMENTS[key]
+        if key == "classes":
+            # Slots live two levels down under `attributes:`; space them there.
+            body = _space_entries_at(_dump_yaml({key: value}).rstrip("\n"), indent=6)
+        elif key in _SPACED_SECTIONS:
+            body = _space_entries_at(_dump_yaml({key: value}).rstrip("\n"), indent=2)
+        else:
+            body = _dump_yaml({key: value}).rstrip("\n")
+        blocks.append(f"# --- {comment} ---\n{body}")
+
+    header = "\n".join(scalar_header)
+    return "\n\n".join([header, *blocks]) + "\n"
 
 
 def _strip_type_keys(obj):

--- a/converter/radx_dd_converter/emit.py
+++ b/converter/radx_dd_converter/emit.py
@@ -388,14 +388,24 @@ class Emitter:
         for prefix, expansion in self._prefixes.items():
             schema.prefixes.setdefault(prefix, expansion)
 
-        # Finalise field-enum descriptions now that the full usage map is known:
-        # name the single data element when an enum is used by exactly one,
-        # otherwise keep the generic wording.
-        for enum_name, users in self._enum_users.items():
+        # Finalise field enums now that the full usage map is known. An enum used
+        # by exactly one data element is renamed after that element (which is
+        # meaningful and unambiguous with a single owner); shared enums keep
+        # their value-derived name. Descriptions are set to match.
+        renames: Dict[str, str] = {}
+        for enum_name, users in list(self._enum_users.items()):
             enum = schema.enums.get(enum_name)
             if enum is None:
                 continue
             if len(users) == 1:
+                new_name = f"{_class_case(users[0])}Enum"
+                # Collision-check against other enums (skip self).
+                n, suffix = new_name, 2
+                while n in schema.enums and n != enum_name:
+                    n, suffix = f"{new_name}{suffix}", suffix + 1
+                new_name = n
+                if new_name != enum_name:
+                    renames[enum_name] = new_name
                 enum.description = (
                     f"Permissible values for the `{users[0]}` data element."
                 )
@@ -405,7 +415,47 @@ class Emitter:
                     f"(see the `used by` annotation)."
                 )
 
+        if renames:
+            self._apply_enum_renames(schema, renames)
+
         return schema
+
+    def _apply_enum_renames(
+        self, schema: SchemaDefinition, renames: Dict[str, str]
+    ) -> None:
+        """Rename enums and re-point every reference to them.
+
+        Updates the ``enums`` mapping keys, the ``range`` of every slot ``any_of``
+        branch (and any direct ``range``) that referenced the old name, and the
+        internal tracking dicts used by the annotation passes.
+        """
+        # Rebuild the enums mapping preserving order, with renamed keys. Keep the
+        # enum's own `name` in sync with its key, else validation rejects the
+        # mismatch (and _drop_redundant_keys only strips `name` when it matches).
+        new_enums = {}
+        for name, enum in schema.enums.items():
+            new_name = renames.get(name, name)
+            enum.name = new_name
+            new_enums[new_name] = enum
+        schema.enums = new_enums
+
+        # Re-point slot ranges (enumerated slots use any_of; be defensive about
+        # a direct range too).
+        for cls in schema.classes.values():
+            for slot in cls.attributes.values():
+                for branch in slot.any_of or []:
+                    if branch.range in renames:
+                        branch.range = renames[branch.range]
+                if slot.range in renames:
+                    slot.range = renames[slot.range]
+
+        # Keep the annotation-tracking dicts consistent with the new names.
+        self._field_enum_values = {
+            renames.get(k, k): v for k, v in self._field_enum_values.items()
+        }
+        self._enum_users = {
+            renames.get(k, k): v for k, v in self._enum_users.items()
+        }
 
     def dumps(self, rows: List[Row]) -> str:
         """Build the schema and dump it as readable YAML.

--- a/converter/radx_dd_converter/grammar/__init__.py
+++ b/converter/radx_dd_converter/grammar/__init__.py
@@ -1,0 +1,17 @@
+"""Parser layer for the RADx data dictionary in-cell mini-grammars."""
+
+from .parse import (
+    EnumItem,
+    ParseError,
+    parse_enumeration,
+    parse_missing_value_codes,
+)
+from .terms import parse_terms
+
+__all__ = [
+    "EnumItem",
+    "ParseError",
+    "parse_enumeration",
+    "parse_missing_value_codes",
+    "parse_terms",
+]

--- a/converter/radx_dd_converter/grammar/enumeration.lark
+++ b/converter/radx_dd_converter/grammar/enumeration.lark
@@ -1,0 +1,36 @@
+// Grammar for the RADx enumeration / missing-value-codes cell syntax.
+//
+// Mirrors the EBNF in radx-data-dictionary-specification.md, section
+// "Semantics of Enumeration Values":
+//
+//   enumeration          = enumerationValuePair {'|' enumerationValuePair} ;
+//   enumerationValuePair = value '=' label [ bracketedIri ] ;
+//   value                = quotedString ;   // "..."  (no unescaped ")
+//   label                = boxedString ;    // [...]  (no unescaped ])
+//   bracketedIri         = "(" (fullIri | oboId) ")" ;
+//
+// White space surrounding the '|' and '=' terminals is not significant; it is
+// discarded via the %ignore directive below. White space *inside* a quoted
+// value or boxed label is significant and is preserved (those terminals match
+// their delimiters explicitly).
+
+enumeration: pair ("|" pair)*
+
+pair: value "=" label bracketed_iri?
+
+value: QUOTED
+label: BOXED
+bracketed_iri: PARENED
+
+// A double-quoted string. The value between the quotes is any run of
+// characters that is not a double quote.
+QUOTED: "\"" /[^"]*/ "\""
+
+// A square-bracketed label. Any run of characters that is not a ']'.
+BOXED: "[" /[^\]]*/ "]"
+
+// A round-bracketed IRI or OBO id. Any run of characters that is not a ')'.
+PARENED: "(" /[^)]*/ ")"
+
+%import common.WS
+%ignore WS

--- a/converter/radx_dd_converter/grammar/parse.py
+++ b/converter/radx_dd_converter/grammar/parse.py
@@ -1,0 +1,99 @@
+"""Parse the RADx enumeration and missing-value-codes cell grammars.
+
+Both the ``Enumeration`` and ``MissingValueCodes`` fields use the same cell
+syntax::
+
+    "value"=[label](optionalTermIri) | "value"=[label] | ...
+
+This module turns such a cell into a list of :class:`EnumItem` objects. White
+space around the ``|`` and ``=`` separators is insignificant; white space inside
+a quoted value or boxed label is preserved.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+from lark import Lark, Token, Tree
+from lark.exceptions import LarkError
+
+_GRAMMAR_PATH = Path(__file__).with_name("enumeration.lark")
+
+# One shared parser instance. LALR is sufficient for this grammar and is fast.
+_parser = Lark(
+    _GRAMMAR_PATH.read_text(encoding="utf-8"),
+    start="enumeration",
+    parser="lalr",
+)
+
+
+class ParseError(ValueError):
+    """Raised when a cell does not conform to the enumeration grammar."""
+
+
+@dataclass(frozen=True)
+class EnumItem:
+    """A single value-label pair from an enumeration or missing-value-codes cell.
+
+    ``value`` is the unquoted value (what appears, unquoted, in a datafile).
+    ``label`` is the human-readable label. ``iri`` is the optional ontology term
+    identifier attached to the value (a full IRI or a compact OBO id), or
+    ``None`` when the pair carries no term.
+    """
+
+    value: str
+    label: str
+    iri: Optional[str] = None
+
+
+def _strip_delims(token: str, open_ch: str, close_ch: str) -> str:
+    """Remove the surrounding delimiter characters from a terminal's text."""
+    assert token.startswith(open_ch) and token.endswith(close_ch), token
+    return token[len(open_ch) : len(token) - len(close_ch)]
+
+
+def _tree_to_items(tree: Tree) -> List[EnumItem]:
+    items: List[EnumItem] = []
+    for pair in tree.children:
+        # Each `pair` is a Tree whose children are: value, label, [bracketed_iri]
+        value_text = label_text = None
+        iri_text: Optional[str] = None
+        for child in pair.children:
+            if not isinstance(child, Tree):
+                continue
+            (leaf,) = child.children  # each of value/label/bracketed_iri holds one token
+            text = str(leaf)
+            if child.data == "value":
+                value_text = _strip_delims(text, '"', '"')
+            elif child.data == "label":
+                label_text = _strip_delims(text, "[", "]")
+            elif child.data == "bracketed_iri":
+                iri_text = _strip_delims(text, "(", ")").strip()
+        items.append(EnumItem(value=value_text, label=label_text, iri=iri_text))
+    return items
+
+
+def parse_enumeration(cell: str) -> List[EnumItem]:
+    """Parse an ``Enumeration`` cell into a list of :class:`EnumItem`.
+
+    A blank or whitespace-only cell yields an empty list. Raises
+    :class:`ParseError` if the cell is non-blank but malformed.
+    """
+    if cell is None or cell.strip() == "":
+        return []
+    try:
+        tree = _parser.parse(cell)
+    except LarkError as exc:
+        raise ParseError(f"Malformed enumeration cell {cell!r}: {exc}") from exc
+    return _tree_to_items(tree)
+
+
+def parse_missing_value_codes(cell: str) -> List[EnumItem]:
+    """Parse a ``MissingValueCodes`` cell.
+
+    Identical grammar to :func:`parse_enumeration`; provided as a separate name
+    because the two fields are semantically distinct (see the specification).
+    """
+    return parse_enumeration(cell)

--- a/converter/radx_dd_converter/grammar/parse.py
+++ b/converter/radx_dd_converter/grammar/parse.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
-from lark import Lark, Token, Tree
+from lark import Lark, Tree
 from lark.exceptions import LarkError
 
 _GRAMMAR_PATH = Path(__file__).with_name("enumeration.lark")

--- a/converter/radx_dd_converter/grammar/terms.py
+++ b/converter/radx_dd_converter/grammar/terms.py
@@ -1,0 +1,31 @@
+"""Parse the RADx ``Terms`` cell into a list of ontology term identifiers.
+
+Per the specification, multiple term identifiers are separated by white space
+(space U+0020 or non-breaking space U+00A0) or newline characters (U+000A). Each
+term is a full IRI or a compact OBO id (e.g. ``UBERON:0001836``). This module
+only tokenises the cell; it does not validate that each token is a well-formed
+IRI/CURIE (that is left to the emitter, which decides how strict to be).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+# The separators the spec allows between terms: ASCII space, non-breaking space,
+# tab, and newline. Any run of these is a single separator.
+_SEPARATOR = re.compile(r"[  \t\r\n]+")
+
+
+def parse_terms(cell: str) -> List[str]:
+    """Split a ``Terms`` cell into its individual term identifiers.
+
+    A blank or whitespace-only cell yields an empty list. Leading and trailing
+    white space is ignored; runs of separators collapse to one.
+    """
+    if cell is None:
+        return []
+    stripped = _SEPARATOR.sub(" ", cell).strip()
+    if stripped == "":
+        return []
+    return stripped.split(" ")

--- a/converter/radx_dd_converter/missing_values.py
+++ b/converter/radx_dd_converter/missing_values.py
@@ -1,0 +1,49 @@
+"""The standard set of RADx missing-value codes.
+
+Per the specification, this standard set of codes always applies to a
+``MissingValueCodes`` field; any codes given in a field's cell *augment* it. The
+emitter renders these as a single shared ``StandardMissingValueCodes`` enum that
+enumerated slots reference (see ``linkml/CONVERTER_PLAN.md``, Option 3).
+
+The codes are stored here as the exact default-value string from the
+specification and parsed with the converter's own parser, so this module cannot
+drift from the enumeration grammar or transcribe a code incorrectly.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from .grammar import EnumItem, parse_missing_value_codes
+
+# The "Standard Codes (Default value)" block from
+# radx-data-dictionary-specification.md, copied verbatim.
+STANDARD_MISSING_VALUE_CODES_TEXT = (
+    '"-9999"=[Reason Unknown] | "-9980"=[Not Sent to Data Hub] '
+    '| "-9981"=[Data Transfer Agreement] '
+    '| "-9982"=[No Participant Consent To Share] '
+    '| "-9983"=[Not Available Or Mappable] '
+    '| "-9984"=[Data Lost Or Inaccessible] | "-9985"=[Data Invalid] '
+    '| "-9986"=[Anonymization Or Privacy Concerns] '
+    '| "-9987"=[Other Unsent Reason Not Specified] '
+    '| "-9960"=[Not Entered By Originator] | "-9961"=[Omitted This Value] '
+    '| "-9962"=[Originator Chose to Omit] | "-9963"=[Question Not Applicable] '
+    '| "-9964"=[Answer Not Known] | "-9965"=[Record Not Provided] '
+    '| "-9966"=[All Originators Omitted Element] '
+    '| "-9967"=[CDE Omitted With Exception] '
+    '| "-9968"=[Other Unentered Reason Not Specified] '
+    '| "-9940"=[Not Presented To Participant] | "-9941"=[Skip Logic] '
+    '| "-9942"=[No Participant Consent to Ask] '
+    '| "-9943"=[CDE Not Presented Due to Exception] '
+    '| "-9944"=[Element Never Presented for Collection] '
+    '| "-9945"=[Process Error] '
+    '| "-9946"=[Other Unpresented Reason Not Specified]'
+)
+
+# Parsed once at import; the canonical list of standard codes.
+STANDARD_MISSING_VALUE_CODES: List[EnumItem] = parse_missing_value_codes(
+    STANDARD_MISSING_VALUE_CODES_TEXT
+)
+
+# The name of the shared enum the emitter generates for these codes.
+STANDARD_ENUM_NAME = "StandardMissingValueCodes"

--- a/converter/radx_dd_converter/reader.py
+++ b/converter/radx_dd_converter/reader.py
@@ -1,0 +1,142 @@
+"""Read a RADx data dictionary CSV into ordered rows.
+
+The reader parses the CSV per RFC 4180 (via the standard library ``csv``
+module), validates the header record, and returns an ordered list of
+:class:`Row` objects. Row order is preserved because the specification says the
+order of data-dictionary records is significant: it corresponds to the order of
+the fields in the target datafile.
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, TextIO, Union
+
+# The canonical header sequence from the specification. Order here is the
+# recommended order; the reader does not require this order (columns are keyed
+# by name), but uses the set to distinguish known from extra columns.
+KNOWN_COLUMNS: Sequence[str] = (
+    "Id",
+    "Aliases",
+    "Label",
+    "Description",
+    "Section",
+    "Cardinality",
+    "Terms",
+    "Datatype",
+    "Pattern",
+    "Unit",
+    "Enumeration",
+    "MissingValueCodes",
+    "Examples",
+    "Notes",
+    "Provenance",
+    "SeeAlso",
+)
+
+# Fields whose value must be present and non-empty (Value Status: REQUIRED).
+REQUIRED_COLUMNS: Sequence[str] = ("Id", "Label", "Datatype")
+
+
+class ReadError(ValueError):
+    """Raised when a data dictionary CSV cannot be read or is invalid."""
+
+
+@dataclass(frozen=True)
+class Row:
+    """One data element (non-header record) of a data dictionary.
+
+    ``cells`` maps column header -> raw cell string (empty string for blank
+    cells). ``line`` is the 1-based line number in the source file, for error
+    messages. Extra (non-canonical) columns are preserved in ``cells`` and
+    listed in ``extra_columns``.
+    """
+
+    cells: Dict[str, str]
+    line: int
+    extra_columns: Sequence[str] = field(default_factory=tuple)
+
+    def get(self, column: str) -> str:
+        """Return the raw cell for ``column`` (empty string if absent/blank)."""
+        return self.cells.get(column, "")
+
+    @property
+    def id(self) -> str:
+        return self.get("Id")
+
+
+def _validate_header(header: Sequence[str]) -> List[str]:
+    """Validate the header record; return the list of extra (non-canonical) columns."""
+    seen = [h.strip() for h in header]
+    # Duplicate headers make column-by-name access ambiguous.
+    dupes = {h for h in seen if seen.count(h) > 1}
+    if dupes:
+        raise ReadError(f"Duplicate column header(s): {', '.join(sorted(dupes))}")
+    missing = [c for c in REQUIRED_COLUMNS if c not in seen]
+    if missing:
+        raise ReadError(
+            "Missing required column header(s): " + ", ".join(missing)
+        )
+    return [h for h in seen if h and h not in KNOWN_COLUMNS]
+
+
+def read_data_dictionary(
+    source: Union[str, Path, TextIO],
+) -> List[Row]:
+    """Read a data dictionary CSV and return its rows in order.
+
+    ``source`` may be a path (``str``/``Path``) or an open text file object.
+
+    Raises :class:`ReadError` on a malformed header, a blank required cell, or a
+    duplicate ``Id``.
+    """
+    if isinstance(source, (str, Path)):
+        with open(source, "r", encoding="utf-8-sig", newline="") as handle:
+            return _read(handle)
+    return _read(source)
+
+
+def _read(handle: TextIO) -> List[Row]:
+    reader = csv.reader(handle)  # RFC 4180 defaults: comma, double-quote
+    try:
+        header = next(reader)
+    except StopIteration:
+        raise ReadError("Data dictionary is empty (no header record).")
+
+    # Strip a UTF-8 BOM from the first header cell. Opening a path uses
+    # encoding="utf-8-sig" which removes it, but a caller-supplied stream may
+    # still carry one (e.g. a file opened as plain utf-8).
+    if header and header[0].startswith("﻿"):
+        header[0] = header[0].lstrip("﻿")
+
+    header = [h.strip() for h in header]
+    extra_columns = tuple(_validate_header(header))
+
+    rows: List[Row] = []
+    seen_ids: Dict[str, int] = {}
+    for offset, raw in enumerate(reader):
+        line = offset + 2  # +1 for header, +1 for 1-based
+        if not any(cell.strip() for cell in raw):
+            continue  # skip wholly blank lines
+
+        cells = {header[i]: (raw[i] if i < len(raw) else "") for i in range(len(header))}
+
+        for req in REQUIRED_COLUMNS:
+            if cells.get(req, "").strip() == "":
+                raise ReadError(
+                    f"Line {line}: required column {req!r} is blank."
+                )
+
+        row_id = cells["Id"].strip()
+        if row_id in seen_ids:
+            raise ReadError(
+                f"Line {line}: duplicate Id {row_id!r} "
+                f"(first seen on line {seen_ids[row_id]})."
+            )
+        seen_ids[row_id] = line
+
+        rows.append(Row(cells=cells, line=line, extra_columns=extra_columns))
+
+    return rows

--- a/converter/radx_dd_converter/reader.py
+++ b/converter/radx_dd_converter/reader.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import csv
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, TextIO, Union
+from typing import Dict, List, Sequence, TextIO, Union
 
 # The canonical header sequence from the specification. Order here is the
 # recommended order; the reader does not require this order (columns are keyed

--- a/converter/radx_dd_converter/reader.py
+++ b/converter/radx_dd_converter/reader.py
@@ -10,9 +10,12 @@ the fields in the target datafile.
 from __future__ import annotations
 
 import csv
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Sequence, TextIO, Union
+
+logger = logging.getLogger(__name__)
 
 # The canonical header sequence from the specification. Order here is the
 # recommended order; the reader does not require this order (columns are keyed
@@ -84,21 +87,25 @@ def _validate_header(header: Sequence[str]) -> List[str]:
 
 def read_data_dictionary(
     source: Union[str, Path, TextIO],
+    *,
+    allow_duplicates: bool = False,
 ) -> List[Row]:
     """Read a data dictionary CSV and return its rows in order.
 
     ``source`` may be a path (``str``/``Path``) or an open text file object.
 
     Raises :class:`ReadError` on a malformed header, a blank required cell, or a
-    duplicate ``Id``.
+    duplicate ``Id``. When ``allow_duplicates`` is true, a duplicate ``Id`` is
+    not fatal: the first occurrence is kept, later occurrences are skipped, and
+    a warning is logged for each.
     """
     if isinstance(source, (str, Path)):
         with open(source, "r", encoding="utf-8-sig", newline="") as handle:
-            return _read(handle)
-    return _read(source)
+            return _read(handle, allow_duplicates)
+    return _read(source, allow_duplicates)
 
 
-def _read(handle: TextIO) -> List[Row]:
+def _read(handle: TextIO, allow_duplicates: bool = False) -> List[Row]:
     reader = csv.reader(handle)  # RFC 4180 defaults: comma, double-quote
     try:
         header = next(reader)
@@ -131,6 +138,15 @@ def _read(handle: TextIO) -> List[Row]:
 
         row_id = cells["Id"].strip()
         if row_id in seen_ids:
+            if allow_duplicates:
+                logger.warning(
+                    "Line %d: duplicate Id %r (first seen on line %d); skipping "
+                    "this occurrence.",
+                    line,
+                    row_id,
+                    seen_ids[row_id],
+                )
+                continue
             raise ReadError(
                 f"Line {line}: duplicate Id {row_id!r} "
                 f"(first seen on line {seen_ids[row_id]})."

--- a/converter/radx_dd_converter/terms_lookup.py
+++ b/converter/radx_dd_converter/terms_lookup.py
@@ -1,13 +1,15 @@
 """Look up human-readable names for ontology term identifiers.
 
 Given the CURIEs / IRIs used in a data dictionary's ``Terms`` and enumeration
-``meaning`` values, resolve each to its label via the EBI Ontology Lookup
-Service (OLS4). Lookups are opt-in (the converter is network-free by default);
-failures are skipped, never fatal.
+``meaning`` values, resolve each to its label using a selectable resolver:
 
-There is no true batch endpoint on OLS4 (repeated ``iri`` / ``short_form``
-parameters are AND-ed), so unique terms are resolved concurrently with a small
-thread pool and cached.
+* ``ols4`` — the EBI Ontology Lookup Service (open, no key required);
+* ``bioportal`` — BioPortal (requires an API key).
+
+Lookups are opt-in (the converter is network-free by default). There is no true
+batch endpoint on either service (repeated id parameters are AND-ed), so unique
+terms are resolved concurrently with a small thread pool and cached. Failures
+are skipped, never fatal.
 """
 
 from __future__ import annotations
@@ -22,19 +24,25 @@ from typing import Dict, Iterable, Optional
 logger = logging.getLogger(__name__)
 
 OLS4_TERMS_URL = "https://www.ebi.ac.uk/ols4/api/terms"
+BIOPORTAL_CLASS_URL = "https://data.bioontology.org/ontologies/{ont}/classes/{iri}"
 _OBO_PURL = "http://purl.obolibrary.org/obo/"
 
 _DEFAULT_TIMEOUT = 15.0
 _DEFAULT_WORKERS = 8
 
+RESOLVERS = ("ols4", "bioportal")
+
+
+class LookupError_(Exception):
+    """Raised for a configuration problem (e.g. BioPortal selected without a key)."""
+
 
 def _to_iri(term: str) -> Optional[str]:
-    """Expand a term to a full IRI for lookup, or return it if already an IRI.
+    """Expand a term to a full IRI, or return it if already an IRI.
 
     OBO-style CURIEs (``MONDO:0004979``) expand deterministically to
     ``http://purl.obolibrary.org/obo/MONDO_0004979``. A full ``http(s)://`` IRI
-    is returned as-is. Anything else (unknown CURIE shape) returns ``None`` and
-    is skipped.
+    is returned as-is. Anything else returns ``None`` and is skipped.
     """
     if term.startswith("http://") or term.startswith("https://"):
         return term
@@ -45,50 +53,89 @@ def _to_iri(term: str) -> Optional[str]:
     return None
 
 
-def _fetch_label(term: str, timeout: float) -> Optional[str]:
-    """Resolve one term to its label via OLS4, or ``None`` on any failure."""
+def _curie_prefix(term: str) -> Optional[str]:
+    """Return the id-space of a CURIE (used as the BioPortal ontology acronym)."""
+    if ":" in term and not term.startswith(("http://", "https://")):
+        return term.split(":", 1)[0]
+    return None
+
+
+def _get_json(url: str, timeout: float, headers: Optional[dict] = None):
+    req = urllib.request.Request(url, headers=headers or {})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.load(resp)
+
+
+def _fetch_ols4(term: str, timeout: float, _key: Optional[str]) -> Optional[str]:
     iri = _to_iri(term)
     if iri is None:
         return None
-    query = urllib.parse.urlencode({"iri": iri})
-    url = f"{OLS4_TERMS_URL}?{query}"
-    try:
-        with urllib.request.urlopen(url, timeout=timeout) as resp:
-            data = json.load(resp)
-        terms = data.get("_embedded", {}).get("terms", [])
-        for t in terms:
-            label = t.get("label")
-            if label:
-                return label
+    url = f"{OLS4_TERMS_URL}?{urllib.parse.urlencode({'iri': iri})}"
+    data = _get_json(url, timeout)
+    for t in data.get("_embedded", {}).get("terms", []):
+        if t.get("label"):
+            return t["label"]
+    return None
+
+
+def _fetch_bioportal(term: str, timeout: float, apikey: Optional[str]) -> Optional[str]:
+    iri = _to_iri(term)
+    ont = _curie_prefix(term)
+    if iri is None or ont is None or not apikey:
         return None
-    except Exception as exc:  # network error, timeout, bad JSON, HTTP error
-        logger.warning("Term lookup failed for %s: %s", term, exc)
-        return None
+    url = BIOPORTAL_CLASS_URL.format(
+        ont=urllib.parse.quote(ont, safe=""),
+        iri=urllib.parse.quote(iri, safe=""),
+    )
+    data = _get_json(
+        url, timeout, headers={"Authorization": f"apikey token={apikey}"}
+    )
+    return data.get("prefLabel")
+
+
+_FETCHERS = {"ols4": _fetch_ols4, "bioportal": _fetch_bioportal}
 
 
 def lookup_labels(
     terms: Iterable[str],
     *,
+    resolver: str = "ols4",
+    apikey: Optional[str] = None,
     timeout: float = _DEFAULT_TIMEOUT,
     workers: int = _DEFAULT_WORKERS,
 ) -> Dict[str, str]:
     """Resolve many terms to labels, concurrently and de-duplicated.
 
-    Returns a mapping of ``term -> label`` containing only the terms that
-    resolved successfully; unresolved terms are simply absent (and a warning is
-    logged for each). The input order does not matter and duplicates are
-    collapsed.
+    ``resolver`` selects the source (``"ols4"`` or ``"bioportal"``). BioPortal
+    requires ``apikey``. Returns ``term -> label`` for terms that resolved;
+    unresolved terms are absent (a warning is logged for each).
     """
+    if resolver not in _FETCHERS:
+        raise LookupError_(f"Unknown resolver {resolver!r}; choose one of {RESOLVERS}.")
+    if resolver == "bioportal" and not apikey:
+        raise LookupError_(
+            "The 'bioportal' resolver requires an API key (set BIOPORTAL_API_KEY "
+            "or pass --bioportal-apikey)."
+        )
+
+    fetch = _FETCHERS[resolver]
     unique = sorted({t.strip() for t in terms if t and t.strip()})
     if not unique:
         return {}
 
+    def one(term: str) -> Optional[str]:
+        try:
+            return fetch(term, timeout, apikey)
+        except Exception as exc:  # network error, timeout, bad JSON, HTTP error
+            logger.warning("Term lookup failed for %s (%s): %s", term, resolver, exc)
+            return None
+
     results: Dict[str, str] = {}
     with ThreadPoolExecutor(max_workers=max(1, workers)) as pool:
-        for term, label in zip(
-            unique, pool.map(lambda t: _fetch_label(t, timeout), unique)
-        ):
+        for term, label in zip(unique, pool.map(one, unique)):
             if label:
                 results[term] = label
-    logger.info("Resolved %d/%d unique terms.", len(results), len(unique))
+    logger.info(
+        "Resolved %d/%d unique terms via %s.", len(results), len(unique), resolver
+    )
     return results

--- a/converter/radx_dd_converter/terms_lookup.py
+++ b/converter/radx_dd_converter/terms_lookup.py
@@ -1,0 +1,94 @@
+"""Look up human-readable names for ontology term identifiers.
+
+Given the CURIEs / IRIs used in a data dictionary's ``Terms`` and enumeration
+``meaning`` values, resolve each to its label via the EBI Ontology Lookup
+Service (OLS4). Lookups are opt-in (the converter is network-free by default);
+failures are skipped, never fatal.
+
+There is no true batch endpoint on OLS4 (repeated ``iri`` / ``short_form``
+parameters are AND-ed), so unique terms are resolved concurrently with a small
+thread pool and cached.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from typing import Dict, Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+OLS4_TERMS_URL = "https://www.ebi.ac.uk/ols4/api/terms"
+_OBO_PURL = "http://purl.obolibrary.org/obo/"
+
+_DEFAULT_TIMEOUT = 15.0
+_DEFAULT_WORKERS = 8
+
+
+def _to_iri(term: str) -> Optional[str]:
+    """Expand a term to a full IRI for lookup, or return it if already an IRI.
+
+    OBO-style CURIEs (``MONDO:0004979``) expand deterministically to
+    ``http://purl.obolibrary.org/obo/MONDO_0004979``. A full ``http(s)://`` IRI
+    is returned as-is. Anything else (unknown CURIE shape) returns ``None`` and
+    is skipped.
+    """
+    if term.startswith("http://") or term.startswith("https://"):
+        return term
+    if ":" in term:
+        idspace, local_id = term.split(":", 1)
+        if idspace and local_id and "/" not in term:
+            return f"{_OBO_PURL}{idspace}_{local_id}"
+    return None
+
+
+def _fetch_label(term: str, timeout: float) -> Optional[str]:
+    """Resolve one term to its label via OLS4, or ``None`` on any failure."""
+    iri = _to_iri(term)
+    if iri is None:
+        return None
+    query = urllib.parse.urlencode({"iri": iri})
+    url = f"{OLS4_TERMS_URL}?{query}"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            data = json.load(resp)
+        terms = data.get("_embedded", {}).get("terms", [])
+        for t in terms:
+            label = t.get("label")
+            if label:
+                return label
+        return None
+    except Exception as exc:  # network error, timeout, bad JSON, HTTP error
+        logger.warning("Term lookup failed for %s: %s", term, exc)
+        return None
+
+
+def lookup_labels(
+    terms: Iterable[str],
+    *,
+    timeout: float = _DEFAULT_TIMEOUT,
+    workers: int = _DEFAULT_WORKERS,
+) -> Dict[str, str]:
+    """Resolve many terms to labels, concurrently and de-duplicated.
+
+    Returns a mapping of ``term -> label`` containing only the terms that
+    resolved successfully; unresolved terms are simply absent (and a warning is
+    logged for each). The input order does not matter and duplicates are
+    collapsed.
+    """
+    unique = sorted({t.strip() for t in terms if t and t.strip()})
+    if not unique:
+        return {}
+
+    results: Dict[str, str] = {}
+    with ThreadPoolExecutor(max_workers=max(1, workers)) as pool:
+        for term, label in zip(
+            unique, pool.map(lambda t: _fetch_label(t, timeout), unique)
+        ):
+            if label:
+                results[term] = label
+    logger.info("Resolved %d/%d unique terms.", len(results), len(unique))
+    return results

--- a/converter/radx_dd_converter/units.py
+++ b/converter/radx_dd_converter/units.py
@@ -1,0 +1,75 @@
+"""Built-in unit table for mapping a RADx ``Unit`` cell to a UnitOfMeasure.
+
+RADx ``Unit`` values are free text (the specification provides no controlled
+list). This module carries the small table of common units from the
+specification's own example table, keyed by both unit name and symbol, so the
+converter can populate a structured LinkML ``unit:`` block (``descriptive_name``,
+``symbol``, and ``ucum_code`` where known) for a recognised unit. Unrecognised
+units fall back to ``symbol = <raw string>`` in the emitter, and the raw cell is
+always preserved as ``annotations.unit_raw`` (see ``linkml/CONVERTER_PLAN.md``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass(frozen=True)
+class UnitOfMeasure:
+    """A structured unit, mirroring the fields of LinkML's UnitOfMeasure."""
+
+    descriptive_name: str
+    symbol: str
+    ucum_code: Optional[str] = None
+
+
+# The "common units" table from radx-data-dictionary-specification.md.
+# (descriptive_name, symbol, ucum_code). UCUM codes are filled where a
+# well-defined code exists; None where the free-text unit has no obvious UCUM
+# form (the emitter simply omits ucum_code in that case).
+_UNIT_TABLE = (
+    UnitOfMeasure("millimeter", "mm", "mm"),
+    UnitOfMeasure("meter", "m", "m"),
+    UnitOfMeasure("inch", "in", "[in_i]"),
+    UnitOfMeasure("foot", "ft", "[ft_i]"),
+    UnitOfMeasure("liter", "L", "L"),
+    UnitOfMeasure("milliliter", "mL", "mL"),
+    UnitOfMeasure("second", "s", "s"),
+    UnitOfMeasure("minute", "min", "min"),
+    UnitOfMeasure("hour", "h", "h"),
+    UnitOfMeasure("day", "d", "d"),
+    UnitOfMeasure("week", "w", "wk"),
+    UnitOfMeasure("degrees Celsius", "°C", "Cel"),
+    UnitOfMeasure("Fahrenheit", "°F", "[degF]"),
+    UnitOfMeasure("kelvin", "K", "K"),
+    UnitOfMeasure("milligram", "mg", "mg"),
+    UnitOfMeasure("gram", "g", "g"),
+    UnitOfMeasure("kilogram", "kg", "kg"),
+    UnitOfMeasure("pound", "lb", "[lb_av]"),
+    UnitOfMeasure("mole", "mol", "mol"),
+    UnitOfMeasure("ampere", "A", "A"),
+    UnitOfMeasure("moles per liter", "mol/L", "mol/L"),
+)
+
+# Lookup by both name and symbol, case-insensitively. A name and a symbol never
+# collide in the spec table, so a single map is unambiguous.
+_LOOKUP: Dict[str, UnitOfMeasure] = {}
+for _u in _UNIT_TABLE:
+    _LOOKUP[_u.descriptive_name.lower()] = _u
+    _LOOKUP[_u.symbol.lower()] = _u
+
+
+def lookup_unit(raw: str) -> Optional[UnitOfMeasure]:
+    """Return the :class:`UnitOfMeasure` for a raw ``Unit`` cell, or ``None``.
+
+    Matches by unit name or symbol, ignoring surrounding white space and case.
+    Returns ``None`` when the unit is not in the built-in table (the emitter
+    then falls back to ``symbol = <raw>``).
+    """
+    if raw is None:
+        return None
+    key = raw.strip().lower()
+    if key == "":
+        return None
+    return _LOOKUP.get(key)

--- a/converter/tests/fixtures/sample.csv
+++ b/converter/tests/fixtures/sample.csv
@@ -1,0 +1,4 @@
+Id,Label,Description,Cardinality,Datatype,Pattern,Enumeration,Examples
+PartId,Participant Id,The participant identifier,single,string,^[NP](\d+)$,,N001|N002
+SampleType,Sample Type,The type of sample collected,single,integer,,"""0""=[Saliva](UBERON:0001836) | ""1""=[Blood](UBERON:0000178)",0
+Symptoms,Symptoms,Reported symptoms,multiple,string,,,cough|headache

--- a/converter/tests/test_cli.py
+++ b/converter/tests/test_cli.py
@@ -1,0 +1,92 @@
+"""Tests for the command-line interface."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from radx_dd_converter.cli import _class_from_name, _name_from_filename, main
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sample.csv"
+
+
+# --- filename / name derivation --------------------------------------------
+
+@pytest.mark.parametrize(
+    "filename, expected_name",
+    [
+        ("gcb.dd.csv", "gcb"),  # .dd suffix stripped
+        ("patient_data.csv", "patient_data"),
+        ("My Data.CSV", "my_data"),
+        ("weird-name.tsv", "weird_name"),
+    ],
+)
+def test_name_from_filename(filename, expected_name):
+    assert _name_from_filename(Path(filename)) == expected_name
+
+
+@pytest.mark.parametrize(
+    "name, expected_class",
+    [
+        ("gcb", "Gcb"),
+        ("patient_data", "PatientData"),
+    ],
+)
+def test_class_from_name(name, expected_class):
+    assert _class_from_name(name) == expected_class
+
+
+# --- run behavior ----------------------------------------------------------
+
+def test_writes_output_file_with_filename_defaults(tmp_path, capsys):
+    out = tmp_path / "out.yaml"
+    rc = main([str(FIXTURE), "-o", str(out)])
+    assert rc == 0
+    schema = yaml.safe_load(out.read_text())
+    assert schema["name"] == "sample"
+    assert schema["id"] == "https://w3id.org/radx/sample"
+    assert list(schema["classes"]) == ["Sample"]  # CamelCase of "sample"
+
+
+def test_flags_override_defaults(tmp_path):
+    out = tmp_path / "out.yaml"
+    rc = main(
+        [
+            str(FIXTURE),
+            "-o",
+            str(out),
+            "--name",
+            "custom",
+            "--id",
+            "https://example.org/custom",
+            "--class-name",
+            "Thing",
+        ]
+    )
+    assert rc == 0
+    schema = yaml.safe_load(out.read_text())
+    assert schema["name"] == "custom"
+    assert schema["id"] == "https://example.org/custom"
+    assert list(schema["classes"]) == ["Thing"]
+
+
+def test_output_to_stdout_by_default(capsys):
+    rc = main([str(FIXTURE)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    schema = yaml.safe_load(out)
+    assert "Record" in schema["classes"] or "Sample" in schema["classes"]
+
+
+def test_missing_input_returns_2(capsys):
+    rc = main(["/no/such/file.csv"])
+    assert rc == 2
+    assert "not found" in capsys.readouterr().err
+
+
+def test_malformed_dictionary_reports_cleanly(tmp_path, capsys):
+    bad = tmp_path / "bad.csv"
+    bad.write_text("Id,Label,Datatype\nA,Label A,\n")  # blank required Datatype
+    rc = main([str(bad)])
+    assert rc == 1
+    assert "error:" in capsys.readouterr().err

--- a/converter/tests/test_cli.py
+++ b/converter/tests/test_cli.py
@@ -90,3 +90,19 @@ def test_malformed_dictionary_reports_cleanly(tmp_path, capsys):
     rc = main([str(bad)])
     assert rc == 1
     assert "error:" in capsys.readouterr().err
+
+
+def test_duplicate_id_fails_but_allow_duplicates_succeeds(tmp_path, capsys):
+    dup = tmp_path / "dup.csv"
+    dup.write_text(
+        "Id,Label,Datatype\nA,First,string\nA,Second,integer\n"
+    )
+    # Without the flag: clean error, exit 1.
+    assert main([str(dup)]) == 1
+    assert "duplicate Id" in capsys.readouterr().err
+    # With the flag: succeeds.
+    out = tmp_path / "out.yaml"
+    assert main([str(dup), "-o", str(out), "--allow-duplicates"]) == 0
+    schema = yaml.safe_load(out.read_text())
+    attrs = list(schema["classes"].values())[0]["attributes"]
+    assert list(attrs) == ["A"]  # duplicate collapsed to the first occurrence

--- a/converter/tests/test_datatypes.py
+++ b/converter/tests/test_datatypes.py
@@ -1,0 +1,80 @@
+"""Tests for the RADx/XSD datatype -> LinkML range mapping."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from radx_dd_converter import (
+    CustomType,
+    UnknownDatatypeError,
+    resolve_datatype,
+)
+
+# The authoritative set of datatype names lives in the LinkML schema's
+# DatatypeEnum. Read it so this test fails if the two ever drift apart.
+_SCHEMA = Path(__file__).resolve().parents[2] / "linkml" / "data-dictionary.yaml"
+
+
+def _datatype_enum_names():
+    schema = yaml.safe_load(_SCHEMA.read_text(encoding="utf-8"))
+    return list(schema["enums"]["DatatypeEnum"]["permissible_values"].keys())
+
+
+def test_every_allowable_datatype_resolves():
+    """Every name in DatatypeEnum must map to a builtin range or a custom type."""
+    unresolved = []
+    for name in _datatype_enum_names():
+        try:
+            resolve_datatype(name)
+        except UnknownDatatypeError:
+            unresolved.append(name)
+    assert unresolved == []
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("string", "string"),
+        ("integer", "integer"),
+        ("long", "integer"),
+        ("positiveInteger", "integer"),
+        ("decimal", "decimal"),
+        ("float", "float"),
+        ("double", "double"),
+        ("boolean", "boolean"),
+        ("date", "date"),
+        ("dateTime", "datetime"),  # note: LinkML spells it datetime
+        ("time", "time"),
+        ("anyURI", "uri"),
+        ("token", "string"),
+    ],
+)
+def test_builtin_mappings(name, expected):
+    assert resolve_datatype(name) == expected
+
+
+def test_timestamp_is_custom_integer_type():
+    result = resolve_datatype("timestamp")
+    assert isinstance(result, CustomType)
+    assert result.typeof == "integer"
+    assert result.pattern == r"^[0-9]+$"
+
+
+def test_date_mdy_is_custom_date_type():
+    result = resolve_datatype("date_mdy")
+    assert isinstance(result, CustomType)
+    assert result.typeof == "date"
+    assert result.pattern == r"^\d{2}/\d{2}/\d{4}$"
+
+
+def test_xsd_custom_type_carries_provenance_uri():
+    result = resolve_datatype("gYearMonth")
+    assert isinstance(result, CustomType)
+    assert result.uri == "xsd:gYearMonth"
+
+
+@pytest.mark.parametrize("bad", ["Integer", "String", "DateTime", "notatype", ""])
+def test_unknown_or_miscased_raises(bad):
+    with pytest.raises(UnknownDatatypeError):
+        resolve_datatype(bad)

--- a/converter/tests/test_emit.py
+++ b/converter/tests/test_emit.py
@@ -213,13 +213,13 @@ def test_description_has_no_trailing_blank_lines_in_output():
 
 def test_entries_are_numbered_n_of_m(schema_yaml):
     # Enums numbered within all enums; the sample fixture yields 2 (field + std).
-    assert "SampleTypeEnum:  # 1 of 2" in schema_yaml
-    assert "StandardMissingValueCodes:  # 2 of 2" in schema_yaml
-    # The single tree_root class is 1 of 1.
-    assert "Record:  # 1 of 1" in schema_yaml
-    # Slots are numbered within all slots (fixture has 3).
-    assert "PartId:  # 1 of 3" in schema_yaml
-    assert "Symptoms:  # 3 of 3" in schema_yaml
+    assert "SampleTypeEnum:  # 1 of 2 enums" in schema_yaml
+    assert "StandardMissingValueCodes:  # 2 of 2 enums" in schema_yaml
+    # The single tree_root class is 1 of 1 (singularised).
+    assert "Record:  # 1 of 1 class" in schema_yaml
+    # Slots are numbered within all slots, labelled "data elements".
+    assert "PartId:  # 1 of 3 data elements" in schema_yaml
+    assert "Symptoms:  # 3 of 3 data elements" in schema_yaml
     # A slot's sub-keys (title/range) are not numbered.
     assert "title: Participant Id\n" in schema_yaml
 
@@ -228,10 +228,10 @@ def test_number_entries_helper_resets_per_section():
     from radx_dd_converter.emit import _number_entries_at
 
     body = "  A:\n    x: 1\n  B:\n    y: 2\n  C:\n    z: 3"
-    out = _number_entries_at(body, indent=2, total=3)
-    assert "  A:  # 1 of 3" in out
-    assert "  B:  # 2 of 3" in out
-    assert "  C:  # 3 of 3" in out
+    out = _number_entries_at(body, indent=2, total=3, label="enums")
+    assert "  A:  # 1 of 3 enums" in out
+    assert "  B:  # 2 of 3 enums" in out
+    assert "  C:  # 3 of 3 enums" in out
     # nested keys (x/y/z) are untouched
     assert "    x: 1\n" in out
 

--- a/converter/tests/test_emit.py
+++ b/converter/tests/test_emit.py
@@ -193,6 +193,24 @@ def test_multiline_description_is_block_scalar():
     assert "description: |" in out  # literal block, not escaped quoted string
 
 
+def test_clean_text_strips_trailing_and_leading_blank_lines():
+    from radx_dd_converter.emit import _clean_text
+
+    # trailing blank lines and per-line trailing spaces removed; internal
+    # newlines and spacing preserved.
+    assert _clean_text("hello   \n\n\n") == "hello"
+    assert _clean_text("\n\nhead\n\nmid\n\n") == "head\n\nmid"
+    assert _clean_text("a  \nb  ") == "a\nb"
+
+
+def test_description_has_no_trailing_blank_lines_in_output():
+    # A description whose cell ends with blank lines must not carry them through.
+    csv = 'Id,Label,Datatype,Description\nA,A,string,"body text\n\n\n"\n'
+    schema = yaml.safe_load(emit_schema(read_data_dictionary(_csv(csv))))
+    desc = schema["classes"]["Record"]["attributes"]["A"]["description"]
+    assert desc == "body text"
+
+
 def test_identical_enumerations_are_deduplicated():
     csv = (
         "Id,Label,Datatype,Enumeration\n"

--- a/converter/tests/test_emit.py
+++ b/converter/tests/test_emit.py
@@ -96,17 +96,30 @@ def test_enumeration_uses_any_of_with_standard_codes(schema):
 def test_enum_values_carry_meaning(schema):
     pvs = schema["enums"]["SampleTypeEnum"]["permissible_values"]
     assert pvs["0"]["meaning"] == "UBERON:0001836"
-    assert pvs["0"]["description"] == "Saliva"
+    assert pvs["0"]["title"] == "Saliva"
 
 
 def test_obo_prefix_is_auto_registered(schema):
     assert schema["prefixes"]["UBERON"] == "http://purl.obolibrary.org/obo/UBERON_"
 
 
+def test_terms_map_to_related_mappings_not_slot_uri():
+    csv = (
+        "Id,Label,Datatype,Terms\n"
+        "age,Age,integer,PATO:0000011 NCIT:C25150\n"
+    )
+    slot = yaml.safe_load(emit_schema(read_data_dictionary(_csv(csv))))[
+        "classes"
+    ]["Record"]["attributes"]["age"]
+    assert slot["related_mappings"] == ["PATO:0000011", "NCIT:C25150"]
+    assert "slot_uri" not in slot
+    assert "exact_mappings" not in slot
+
+
 def test_standard_codes_enum_present_and_complete(schema):
     pvs = schema["enums"]["StandardMissingValueCodes"]["permissible_values"]
     assert len(pvs) == 25
-    assert pvs["-9999"]["description"] == "Reason Unknown"
+    assert pvs["-9999"]["title"] == "Reason Unknown"
 
 
 def test_custom_type_emitted_for_timestamp():
@@ -153,6 +166,22 @@ def test_pretty_rendering_preserves_content(schema_yaml):
     from radx_dd_converter.emit import _render
 
     assert yaml.safe_load(_render(ref)) == ref
+
+
+def test_redundant_name_and_text_keys_dropped(schema_yaml, schema):
+    # `name:` is inferred from the mapping key; it should not be emitted.
+    assert "\n    name:" not in schema_yaml and "\n        name:" not in schema_yaml
+    # Permissible-value `text:` equal to its key should be dropped.
+    pvs = schema["enums"]["SampleTypeEnum"]["permissible_values"]
+    assert "text" not in pvs["0"]
+    assert pvs["0"]["title"] == "Saliva"
+    # Class / enum names still resolve (they come from the keys).
+    assert "Record" in schema["classes"]
+    assert "SampleTypeEnum" in schema["enums"]
+
+
+def test_header_comment_present(schema_yaml):
+    assert schema_yaml.startswith("# LinkML schema generated from a RADx data dictionary")
 
 
 def test_multiline_description_is_block_scalar():

--- a/converter/tests/test_emit.py
+++ b/converter/tests/test_emit.py
@@ -93,6 +93,12 @@ def test_enumeration_uses_any_of_with_standard_codes(schema):
     assert sample_type["annotations"]["value_datatype"] == "integer"
 
 
+def test_field_enum_has_synthesized_description(schema):
+    assert schema["enums"]["SampleTypeEnum"]["description"].startswith(
+        "A controlled set of values"
+    )
+
+
 def test_enum_values_carry_meaning(schema):
     pvs = schema["enums"]["SampleTypeEnum"]["permissible_values"]
     assert pvs["0"]["meaning"] == "UBERON:0001836"

--- a/converter/tests/test_emit.py
+++ b/converter/tests/test_emit.py
@@ -236,6 +236,26 @@ def test_number_entries_helper_resets_per_section():
     assert "    x: 1\n" in out
 
 
+def test_annotate_enum_usage_lists_using_data_elements():
+    rows = read_data_dictionary(FIXTURES / "sample.csv")
+    out = emit_schema(
+        rows,
+        EmitOptions(schema_name="s", class_name="Record", annotate_enum_usage=True),
+    )
+    # Appended to the enum's existing "n of m enums" numbering comment.
+    assert "SampleTypeEnum:  # 1 of 2 enums; used by: SampleType" in out
+    # StandardMissingValueCodes is not a field enum -> no "used by".
+    assert "StandardMissingValueCodes:  # 2 of 2 enums\n" in out
+
+
+def test_annotate_enum_usage_dedup_and_cap():
+    from radx_dd_converter.emit import _annotate_enum_usage
+
+    users = {"E": [f"f{i}" for i in range(10)]}
+    out = _annotate_enum_usage("  E:  # 1 of 1 enum\n", users)
+    assert "used by: f0 | f1 | f2 | f3 | f4 | f5 (+4 more)" in out
+
+
 def test_annotate_enum_values_off_by_default(schema_yaml):
     # Default output: no value comment after the enum range.
     assert "range: SampleTypeEnum\n" in schema_yaml

--- a/converter/tests/test_emit.py
+++ b/converter/tests/test_emit.py
@@ -263,8 +263,9 @@ def test_description_has_no_trailing_blank_lines_in_output():
 
 
 def test_entries_are_numbered_n_of_m(schema_yaml):
-    # Enums numbered within all enums; the sample fixture yields 2 (field + std).
-    assert "SampleTypeEnum:  # 1 of 2 enums" in schema_yaml
+    # Field enums carry their number in the 3-line block above (not trailing).
+    assert "# Enum 1 of 2\n" in schema_yaml
+    # StandardMissingValueCodes (not a field enum) keeps a trailing counter.
     assert "StandardMissingValueCodes:  # 2 of 2 enums" in schema_yaml
     # The single tree_root class is 1 of 1 (singularised).
     assert "Record:  # 1 of 1 class" in schema_yaml
@@ -273,6 +274,16 @@ def test_entries_are_numbered_n_of_m(schema_yaml):
     assert "Symptoms:  # 3 of 3 data elements" in schema_yaml
     # A slot's sub-keys (title/range) are not numbered.
     assert "title: Participant Id\n" in schema_yaml
+
+
+def test_field_enum_block_above_definition(schema_yaml):
+    # The 3-line block appears immediately above the enum's (bare) key line.
+    assert (
+        "# Enum 1 of 2\n"
+        "  # Used by 1 data element\n"
+        "  # SampleType\n"
+        "  SampleTypeEnum:\n"
+    ) in schema_yaml
 
 
 def test_number_entries_helper_resets_per_section():
@@ -287,24 +298,23 @@ def test_number_entries_helper_resets_per_section():
     assert "    x: 1\n" in out
 
 
-def test_annotate_enum_usage_lists_using_data_elements():
-    rows = read_data_dictionary(FIXTURES / "sample.csv")
-    out = emit_schema(
-        rows,
-        EmitOptions(schema_name="s", class_name="Record", annotate_enum_usage=True),
-    )
-    # Appended to the enum's existing "n of m enums" numbering comment.
-    assert "SampleTypeEnum:  # 1 of 2 enums; used by: SampleType" in out
-    # StandardMissingValueCodes is not a field enum -> no "used by".
-    assert "StandardMissingValueCodes:  # 2 of 2 enums\n" in out
-
-
-def test_annotate_enum_usage_dedup_and_cap():
-    from radx_dd_converter.emit import _annotate_enum_usage
+def test_enum_block_usage_line_and_cap():
+    from radx_dd_converter.emit import _annotate_enum_blocks
 
     users = {"E": [f"f{i}" for i in range(10)]}
-    out = _annotate_enum_usage("  E:  # 1 of 1 enum\n", users)
-    assert "used by: f0 | f1 | f2 | f3 | f4 | f5 (+4 more)" in out
+    # Feed the line as _render would produce it (with the trailing counter).
+    out = _annotate_enum_blocks("  E:  # 3 of 5 enums\n", users)
+    assert "# Enum 3 of 5\n" in out
+    assert "# Used by 10 data elements\n" in out
+    assert "# f0 | f1 | f2 | f3 | f4 | f5 (+4 more)\n" in out
+    assert "  E:\n" in out  # bare key line
+
+
+def test_enum_block_singular_data_element():
+    from radx_dd_converter.emit import _annotate_enum_blocks
+
+    out = _annotate_enum_blocks("  E:  # 1 of 1 enum\n", {"E": ["only"]})
+    assert "# Used by 1 data element\n" in out  # singular
 
 
 def test_annotate_enum_values_off_by_default(schema_yaml):

--- a/converter/tests/test_emit.py
+++ b/converter/tests/test_emit.py
@@ -211,6 +211,31 @@ def test_description_has_no_trailing_blank_lines_in_output():
     assert desc == "body text"
 
 
+def test_entries_are_numbered_n_of_m(schema_yaml):
+    # Enums numbered within all enums; the sample fixture yields 2 (field + std).
+    assert "SampleTypeEnum:  # 1 of 2" in schema_yaml
+    assert "StandardMissingValueCodes:  # 2 of 2" in schema_yaml
+    # The single tree_root class is 1 of 1.
+    assert "Record:  # 1 of 1" in schema_yaml
+    # Slots are numbered within all slots (fixture has 3).
+    assert "PartId:  # 1 of 3" in schema_yaml
+    assert "Symptoms:  # 3 of 3" in schema_yaml
+    # A slot's sub-keys (title/range) are not numbered.
+    assert "title: Participant Id\n" in schema_yaml
+
+
+def test_number_entries_helper_resets_per_section():
+    from radx_dd_converter.emit import _number_entries_at
+
+    body = "  A:\n    x: 1\n  B:\n    y: 2\n  C:\n    z: 3"
+    out = _number_entries_at(body, indent=2, total=3)
+    assert "  A:  # 1 of 3" in out
+    assert "  B:  # 2 of 3" in out
+    assert "  C:  # 3 of 3" in out
+    # nested keys (x/y/z) are untouched
+    assert "    x: 1\n" in out
+
+
 def test_annotate_enum_values_off_by_default(schema_yaml):
     # Default output: no value comment after the enum range.
     assert "range: SampleTypeEnum\n" in schema_yaml

--- a/converter/tests/test_emit.py
+++ b/converter/tests/test_emit.py
@@ -129,6 +129,41 @@ def test_unit_lookup_and_raw_preserved():
     assert slot["annotations"]["unit_raw"] == "mm"
 
 
+def test_output_has_section_comments_and_blank_lines(schema_yaml):
+    assert "# --- Slots ---" not in schema_yaml  # slots live under Classes
+    assert "# --- Classes ---" in schema_yaml
+    assert "# --- Enumerations ---" in schema_yaml
+    # A blank line separates slots (two attribute keys with a blank between).
+    assert "\n\n      PartId:" in schema_yaml or "\n\n      SampleType:" in schema_yaml
+
+
+def test_pretty_rendering_preserves_content(schema_yaml):
+    """The comment/blank-line pass must not alter the schema data."""
+    import json
+
+    from linkml_runtime.dumpers import json_dumper
+
+    from radx_dd_converter import read_data_dictionary
+    from radx_dd_converter.emit import Emitter, EmitOptions, _strip_type_keys
+
+    em = Emitter(EmitOptions(schema_id="https://example.org/s", schema_name="s",
+                             class_name="Record"))
+    schema = em.build(read_data_dictionary(FIXTURES / "sample.csv"))
+    ref = _strip_type_keys(json.loads(json_dumper.dumps(schema)))
+    from radx_dd_converter.emit import _render
+
+    assert yaml.safe_load(_render(ref)) == ref
+
+
+def test_multiline_description_is_block_scalar():
+    csv = (
+        "Id,Label,Datatype,Description\n"
+        'A,A,string,"line one' "\n" 'line two"\n'
+    )
+    out = emit_schema(read_data_dictionary(_csv(csv)))
+    assert "description: |" in out  # literal block, not escaped quoted string
+
+
 def test_identical_enumerations_are_deduplicated():
     csv = (
         "Id,Label,Datatype,Enumeration\n"

--- a/converter/tests/test_emit.py
+++ b/converter/tests/test_emit.py
@@ -197,8 +197,8 @@ def test_output_has_section_comments_and_blank_lines(schema_yaml):
     assert "# --- Slots ---" not in schema_yaml  # slots live under Classes
     assert "# --- Classes ---" in schema_yaml
     assert "# --- Enumerations ---" in schema_yaml
-    # A blank line separates slots (two attribute keys with a blank between).
-    assert "\n\n      PartId:" in schema_yaml or "\n\n      SampleType:" in schema_yaml
+    # A blank line separates slots; each slot carries a 1-line block above it.
+    assert "\n\n      # Data element 2 of 3\n      SampleType:" in schema_yaml
 
 
 def test_pretty_rendering_preserves_content(schema_yaml):
@@ -269,9 +269,9 @@ def test_entries_are_numbered_n_of_m(schema_yaml):
     assert "StandardMissingValueCodes:  # 2 of 2 enums" in schema_yaml
     # The single tree_root class is 1 of 1 (singularised).
     assert "Record:  # 1 of 1 class" in schema_yaml
-    # Slots are numbered within all slots, labelled "data elements".
-    assert "PartId:  # 1 of 3 data elements" in schema_yaml
-    assert "Symptoms:  # 3 of 3 data elements" in schema_yaml
+    # Data elements carry their number in a 1-line block above the slot.
+    assert "# Data element 1 of 3\n      PartId:" in schema_yaml
+    assert "# Data element 3 of 3\n      Symptoms:" in schema_yaml
     # A slot's sub-keys (title/range) are not numbered.
     assert "title: Participant Id\n" in schema_yaml
 
@@ -299,11 +299,11 @@ def test_number_entries_helper_resets_per_section():
 
 
 def test_enum_block_usage_line_and_cap():
-    from radx_dd_converter.emit import _annotate_enum_blocks
+    from radx_dd_converter.emit import _annotate_blocks
 
     users = {"E": [f"f{i}" for i in range(10)]}
     # Feed the line as _render would produce it (with the trailing counter).
-    out = _annotate_enum_blocks("  E:  # 3 of 5 enums\n", users)
+    out = _annotate_blocks("  E:  # 3 of 5 enums\n", 2, "Enum", "enums", users)
     assert "# Enum 3 of 5\n" in out
     assert "# Used by 10 data elements\n" in out
     assert "# f0 | f1 | f2 | f3 | f4 | f5 (+4 more)\n" in out
@@ -311,10 +311,34 @@ def test_enum_block_usage_line_and_cap():
 
 
 def test_enum_block_singular_data_element():
-    from radx_dd_converter.emit import _annotate_enum_blocks
+    from radx_dd_converter.emit import _annotate_blocks
 
-    out = _annotate_enum_blocks("  E:  # 1 of 1 enum\n", {"E": ["only"]})
+    out = _annotate_blocks("  E:  # 1 of 1 enum\n", 2, "Enum", "enums", {"E": ["only"]})
     assert "# Used by 1 data element\n" in out  # singular
+
+
+def test_data_element_one_line_block():
+    from radx_dd_converter.emit import _annotate_blocks
+
+    # No users map -> a one-line "# Data element n of m" block, bare key line.
+    out = _annotate_blocks(
+        "      age:  # 2 of 5 data elements\n", 6, "Data element", "data elements"
+    )
+    assert "      # Data element 2 of 5\n" in out
+    assert "      age:\n" in out
+    assert "Used by" not in out  # data elements have no used-by line
+
+
+def test_section_block_three_lines():
+    from radx_dd_converter.emit import _annotate_blocks
+
+    out = _annotate_blocks(
+        "  Demographics:  # 3 of 4 sections\n",
+        2, "Section", "sections", {"Demographics": ["a", "b"]},
+    )
+    assert "# Section 3 of 4\n" in out
+    assert "# Used by 2 data elements\n" in out
+    assert "# a | b\n" in out
 
 
 def test_annotate_enum_values_off_by_default(schema_yaml):

--- a/converter/tests/test_emit.py
+++ b/converter/tests/test_emit.py
@@ -88,15 +88,15 @@ def test_examples_are_split_on_pipe(schema):
 def test_enumeration_uses_any_of_with_standard_codes(schema):
     sample_type = schema["classes"]["Record"]["attributes"]["SampleType"]
     ranges = [b["range"] for b in sample_type["any_of"]]
-    assert ranges == ["SampleTypeEnum", "StandardMissingValueCodes"]
+    assert ranges == ["SalivaBloodEnum", "StandardMissingValueCodes"]
     # underlying datatype is preserved (annotations serialize as bare strings)
     assert sample_type["annotations"]["value_datatype"] == "integer"
 
 
 def test_single_user_enum_names_its_data_element(schema):
-    # SampleType is the only user of SampleTypeEnum -> named in the description.
+    # SampleType is the only user of SalivaBloodEnum -> named in the description.
     assert (
-        schema["enums"]["SampleTypeEnum"]["description"]
+        schema["enums"]["SalivaBloodEnum"]["description"]
         == "Permissible values for the `SampleType` data element."
     )
 
@@ -115,7 +115,7 @@ def test_shared_enum_description_is_generic():
 
 
 def test_enum_values_carry_meaning(schema):
-    pvs = schema["enums"]["SampleTypeEnum"]["permissible_values"]
+    pvs = schema["enums"]["SalivaBloodEnum"]["permissible_values"]
     assert pvs["0"]["meaning"] == "UBERON:0001836"
     assert pvs["0"]["title"] == "Saliva"
 
@@ -193,12 +193,12 @@ def test_redundant_name_and_text_keys_dropped(schema_yaml, schema):
     # `name:` is inferred from the mapping key; it should not be emitted.
     assert "\n    name:" not in schema_yaml and "\n        name:" not in schema_yaml
     # Permissible-value `text:` equal to its key should be dropped.
-    pvs = schema["enums"]["SampleTypeEnum"]["permissible_values"]
+    pvs = schema["enums"]["SalivaBloodEnum"]["permissible_values"]
     assert "text" not in pvs["0"]
     assert pvs["0"]["title"] == "Saliva"
     # Class / enum names still resolve (they come from the keys).
     assert "Record" in schema["classes"]
-    assert "SampleTypeEnum" in schema["enums"]
+    assert "SalivaBloodEnum" in schema["enums"]
 
 
 def test_header_comment_present(schema_yaml):
@@ -234,7 +234,7 @@ def test_description_has_no_trailing_blank_lines_in_output():
 
 def test_entries_are_numbered_n_of_m(schema_yaml):
     # Enums numbered within all enums; the sample fixture yields 2 (field + std).
-    assert "SampleTypeEnum:  # 1 of 2 enums" in schema_yaml
+    assert "SalivaBloodEnum:  # 1 of 2 enums" in schema_yaml
     assert "StandardMissingValueCodes:  # 2 of 2 enums" in schema_yaml
     # The single tree_root class is 1 of 1 (singularised).
     assert "Record:  # 1 of 1 class" in schema_yaml
@@ -264,7 +264,7 @@ def test_annotate_enum_usage_lists_using_data_elements():
         EmitOptions(schema_name="s", class_name="Record", annotate_enum_usage=True),
     )
     # Appended to the enum's existing "n of m enums" numbering comment.
-    assert "SampleTypeEnum:  # 1 of 2 enums; used by: SampleType" in out
+    assert "SalivaBloodEnum:  # 1 of 2 enums; used by: SampleType" in out
     # StandardMissingValueCodes is not a field enum -> no "used by".
     assert "StandardMissingValueCodes:  # 2 of 2 enums\n" in out
 
@@ -279,7 +279,7 @@ def test_annotate_enum_usage_dedup_and_cap():
 
 def test_annotate_enum_values_off_by_default(schema_yaml):
     # Default output: no value comment after the enum range.
-    assert "range: SampleTypeEnum\n" in schema_yaml
+    assert "range: SalivaBloodEnum\n" in schema_yaml
     assert "# 0=Saliva" not in schema_yaml
 
 
@@ -289,7 +289,7 @@ def test_annotate_enum_values_adds_capped_comment():
         rows,
         EmitOptions(schema_name="s", class_name="Record", annotate_enum_values=True),
     )
-    assert "- range: SampleTypeEnum  # 0=Saliva | 1=Blood" in out
+    assert "- range: SalivaBloodEnum  # 0=Saliva | 1=Blood" in out
     # StandardMissingValueCodes is not a field enum -> never annotated.
     assert "range: StandardMissingValueCodes  #" not in out
 

--- a/converter/tests/test_emit.py
+++ b/converter/tests/test_emit.py
@@ -1,0 +1,147 @@
+"""Tests for the schema emitter.
+
+The headline test converts the fixture dictionary and lints the *generated*
+schema, asserting zero errors: the emitter must always produce a valid LinkML
+schema. The remaining tests check specific mapping decisions from the plan.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from radx_dd_converter import read_data_dictionary
+from radx_dd_converter.emit import EmitOptions, Emitter, emit_schema
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def schema_yaml():
+    rows = read_data_dictionary(FIXTURES / "sample.csv")
+    return emit_schema(
+        rows,
+        EmitOptions(
+            schema_id="https://example.org/s",
+            schema_name="s",
+            class_name="Record",
+        ),
+    )
+
+
+@pytest.fixture
+def schema(schema_yaml):
+    return yaml.safe_load(schema_yaml)
+
+
+def _find_linter():
+    """Locate the linkml-lint console script next to the running interpreter."""
+    candidate = Path(sys.executable).with_name("linkml-lint")
+    if candidate.exists():
+        return str(candidate)
+    from shutil import which
+
+    return which("linkml-lint")
+
+
+def test_generated_schema_lints_clean(schema_yaml, tmp_path):
+    """The emitter must always produce a schema that linkml-lint accepts."""
+    linter = _find_linter()
+    if linter is None:
+        pytest.skip("linkml-lint not available")
+    path = tmp_path / "generated.yaml"
+    path.write_text(schema_yaml, encoding="utf-8")
+    result = subprocess.run(
+        [linter, str(path)], capture_output=True, text=True, env=os.environ
+    )
+    error_lines = [ln for ln in result.stdout.splitlines() if "  error  " in ln]
+    assert error_lines == [], "\n".join(error_lines)
+
+
+def test_root_class_and_slot_order(schema):
+    cls = schema["classes"]["Record"]
+    assert cls["tree_root"] is True
+    # Slot order preserves datafile field order.
+    assert list(cls["attributes"].keys()) == ["PartId", "SampleType", "Symptoms"]
+
+
+def test_label_becomes_title_and_pattern_verbatim(schema):
+    part = schema["classes"]["Record"]["attributes"]["PartId"]
+    assert part["title"] == "Participant Id"
+    assert part["pattern"] == r"^[NP](\d+)$"
+    assert part["range"] == "string"
+
+
+def test_cardinality_multiple_becomes_multivalued(schema):
+    symptoms = schema["classes"]["Record"]["attributes"]["Symptoms"]
+    assert symptoms.get("multivalued") is True
+
+
+def test_examples_are_split_on_pipe(schema):
+    part = schema["classes"]["Record"]["attributes"]["PartId"]
+    assert [e["value"] for e in part["examples"]] == ["N001", "N002"]
+
+
+def test_enumeration_uses_any_of_with_standard_codes(schema):
+    sample_type = schema["classes"]["Record"]["attributes"]["SampleType"]
+    ranges = [b["range"] for b in sample_type["any_of"]]
+    assert ranges == ["SampleTypeEnum", "StandardMissingValueCodes"]
+    # underlying datatype is preserved (annotations serialize as bare strings)
+    assert sample_type["annotations"]["value_datatype"] == "integer"
+
+
+def test_enum_values_carry_meaning(schema):
+    pvs = schema["enums"]["SampleTypeEnum"]["permissible_values"]
+    assert pvs["0"]["meaning"] == "UBERON:0001836"
+    assert pvs["0"]["description"] == "Saliva"
+
+
+def test_obo_prefix_is_auto_registered(schema):
+    assert schema["prefixes"]["UBERON"] == "http://purl.obolibrary.org/obo/UBERON_"
+
+
+def test_standard_codes_enum_present_and_complete(schema):
+    pvs = schema["enums"]["StandardMissingValueCodes"]["permissible_values"]
+    assert len(pvs) == 25
+    assert pvs["-9999"]["description"] == "Reason Unknown"
+
+
+def test_custom_type_emitted_for_timestamp():
+    rows = read_data_dictionary(
+        _csv("Id,Label,Datatype\nWhen,When,timestamp\n")
+    )
+    schema = yaml.safe_load(emit_schema(rows))
+    assert "timestamp" in schema["types"]
+    assert schema["types"]["timestamp"]["typeof"] == "integer"
+    assert schema["classes"]["Record"]["attributes"]["When"]["range"] == "timestamp"
+
+
+def test_unit_lookup_and_raw_preserved():
+    rows = read_data_dictionary(
+        _csv("Id,Label,Datatype,Unit\nHeight,Height,decimal,mm\n")
+    )
+    slot = yaml.safe_load(emit_schema(rows))["classes"]["Record"]["attributes"]["Height"]
+    assert slot["unit"]["descriptive_name"] == "millimeter"
+    assert slot["unit"]["symbol"] == "mm"
+    assert slot["annotations"]["unit_raw"] == "mm"
+
+
+def test_identical_enumerations_are_deduplicated():
+    csv = (
+        "Id,Label,Datatype,Enumeration\n"
+        'A,A,integer,"""0""=[No] | ""1""=[Yes]"\n'
+        'B,B,integer,"""0""=[No] | ""1""=[Yes]"\n'
+    )
+    schema = yaml.safe_load(emit_schema(read_data_dictionary(_csv(csv))))
+    enum_names = [n for n in schema["enums"] if n != "StandardMissingValueCodes"]
+    # Both slots share one generated enum.
+    assert len(enum_names) == 1
+
+
+def _csv(text: str):
+    import io
+
+    return io.StringIO(text)

--- a/converter/tests/test_emit.py
+++ b/converter/tests/test_emit.py
@@ -93,10 +93,25 @@ def test_enumeration_uses_any_of_with_standard_codes(schema):
     assert sample_type["annotations"]["value_datatype"] == "integer"
 
 
-def test_field_enum_has_synthesized_description(schema):
-    assert schema["enums"]["SampleTypeEnum"]["description"].startswith(
-        "A controlled set of values"
+def test_single_user_enum_names_its_data_element(schema):
+    # SampleType is the only user of SampleTypeEnum -> named in the description.
+    assert (
+        schema["enums"]["SampleTypeEnum"]["description"]
+        == "Permissible values for the `SampleType` data element."
     )
+
+
+def test_shared_enum_description_is_generic():
+    # Two data elements share one enumeration -> description mentions the count,
+    # not a single field.
+    csv = (
+        "Id,Label,Datatype,Enumeration\n"
+        'A,A,integer,"""0""=[No] | ""1""=[Yes]"\n'
+        'B,B,integer,"""0""=[No] | ""1""=[Yes]"\n'
+    )
+    schema = yaml.safe_load(emit_schema(read_data_dictionary(_csv(csv))))
+    enum = next(v for k, v in schema["enums"].items() if k != "StandardMissingValueCodes")
+    assert "shared by 2 data elements" in enum["description"]
 
 
 def test_enum_values_carry_meaning(schema):

--- a/converter/tests/test_emit.py
+++ b/converter/tests/test_emit.py
@@ -211,6 +211,34 @@ def test_description_has_no_trailing_blank_lines_in_output():
     assert desc == "body text"
 
 
+def test_annotate_enum_values_off_by_default(schema_yaml):
+    # Default output: no value comment after the enum range.
+    assert "range: SampleTypeEnum\n" in schema_yaml
+    assert "# 0=Saliva" not in schema_yaml
+
+
+def test_annotate_enum_values_adds_capped_comment():
+    rows = read_data_dictionary(FIXTURES / "sample.csv")
+    out = emit_schema(
+        rows,
+        EmitOptions(schema_name="s", class_name="Record", annotate_enum_values=True),
+    )
+    assert "- range: SampleTypeEnum  # 0=Saliva | 1=Blood" in out
+    # StandardMissingValueCodes is not a field enum -> never annotated.
+    assert "range: StandardMissingValueCodes  #" not in out
+
+
+def test_enum_value_comment_is_capped():
+    from radx_dd_converter.emit import _annotate_enum_ranges
+
+    pairs = [(str(i), f"L{i}") for i in range(10)]
+    out = _annotate_enum_ranges(
+        "        - range: BigEnum\n", {"BigEnum": pairs}
+    )
+    assert "(+4 more)" in out  # 10 values, cap 6 -> 4 hidden
+    assert out.count("=") == 6  # exactly 6 value=label pairs shown
+
+
 def test_identical_enumerations_are_deduplicated():
     csv = (
         "Id,Label,Datatype,Enumeration\n"

--- a/converter/tests/test_emit.py
+++ b/converter/tests/test_emit.py
@@ -88,17 +88,47 @@ def test_examples_are_split_on_pipe(schema):
 def test_enumeration_uses_any_of_with_standard_codes(schema):
     sample_type = schema["classes"]["Record"]["attributes"]["SampleType"]
     ranges = [b["range"] for b in sample_type["any_of"]]
-    assert ranges == ["SalivaBloodEnum", "StandardMissingValueCodes"]
+    assert ranges == ["SampleTypeEnum", "StandardMissingValueCodes"]
     # underlying datatype is preserved (annotations serialize as bare strings)
     assert sample_type["annotations"]["value_datatype"] == "integer"
 
 
 def test_single_user_enum_names_its_data_element(schema):
-    # SampleType is the only user of SalivaBloodEnum -> named in the description.
+    # SampleType is the only user of SampleTypeEnum -> named in the description.
     assert (
-        schema["enums"]["SalivaBloodEnum"]["description"]
+        schema["enums"]["SampleTypeEnum"]["description"]
         == "Permissible values for the `SampleType` data element."
     )
+
+
+def test_single_use_enum_named_after_data_element():
+    # One data element -> enum named DataElementCamelCaseEnum, referenced correctly.
+    csv = 'Id,Label,Datatype,Enumeration\nsample_type,ST,integer,"""0""=[Saliva] | ""1""=[Blood]"\n'
+    schema = yaml.safe_load(emit_schema(read_data_dictionary(_csv(csv))))
+    assert "SampleTypeEnum" in schema["enums"]
+    ranges = [
+        b["range"]
+        for b in schema["classes"]["Record"]["attributes"]["sample_type"]["any_of"]
+    ]
+    assert "SampleTypeEnum" in ranges  # reference re-pointed to the new name
+
+
+def test_shared_enum_keeps_value_derived_name():
+    # Two data elements share the enum -> value-derived name, not either field.
+    csv = (
+        "Id,Label,Datatype,Enumeration\n"
+        'q1,Q1,integer,"""0""=[No] | ""1""=[Yes]"\n'
+        'q2,Q2,integer,"""0""=[No] | ""1""=[Yes]"\n'
+    )
+    schema = yaml.safe_load(emit_schema(read_data_dictionary(_csv(csv))))
+    names = [n for n in schema["enums"] if n != "StandardMissingValueCodes"]
+    assert names == ["NoYesEnum"]  # not Q1Enum / Q2Enum
+    for f in ("q1", "q2"):
+        ranges = [
+            b["range"]
+            for b in schema["classes"]["Record"]["attributes"][f]["any_of"]
+        ]
+        assert "NoYesEnum" in ranges
 
 
 def test_shared_enum_description_is_generic():
@@ -115,7 +145,7 @@ def test_shared_enum_description_is_generic():
 
 
 def test_enum_values_carry_meaning(schema):
-    pvs = schema["enums"]["SalivaBloodEnum"]["permissible_values"]
+    pvs = schema["enums"]["SampleTypeEnum"]["permissible_values"]
     assert pvs["0"]["meaning"] == "UBERON:0001836"
     assert pvs["0"]["title"] == "Saliva"
 
@@ -193,12 +223,12 @@ def test_redundant_name_and_text_keys_dropped(schema_yaml, schema):
     # `name:` is inferred from the mapping key; it should not be emitted.
     assert "\n    name:" not in schema_yaml and "\n        name:" not in schema_yaml
     # Permissible-value `text:` equal to its key should be dropped.
-    pvs = schema["enums"]["SalivaBloodEnum"]["permissible_values"]
+    pvs = schema["enums"]["SampleTypeEnum"]["permissible_values"]
     assert "text" not in pvs["0"]
     assert pvs["0"]["title"] == "Saliva"
     # Class / enum names still resolve (they come from the keys).
     assert "Record" in schema["classes"]
-    assert "SalivaBloodEnum" in schema["enums"]
+    assert "SampleTypeEnum" in schema["enums"]
 
 
 def test_header_comment_present(schema_yaml):
@@ -234,7 +264,7 @@ def test_description_has_no_trailing_blank_lines_in_output():
 
 def test_entries_are_numbered_n_of_m(schema_yaml):
     # Enums numbered within all enums; the sample fixture yields 2 (field + std).
-    assert "SalivaBloodEnum:  # 1 of 2 enums" in schema_yaml
+    assert "SampleTypeEnum:  # 1 of 2 enums" in schema_yaml
     assert "StandardMissingValueCodes:  # 2 of 2 enums" in schema_yaml
     # The single tree_root class is 1 of 1 (singularised).
     assert "Record:  # 1 of 1 class" in schema_yaml
@@ -264,7 +294,7 @@ def test_annotate_enum_usage_lists_using_data_elements():
         EmitOptions(schema_name="s", class_name="Record", annotate_enum_usage=True),
     )
     # Appended to the enum's existing "n of m enums" numbering comment.
-    assert "SalivaBloodEnum:  # 1 of 2 enums; used by: SampleType" in out
+    assert "SampleTypeEnum:  # 1 of 2 enums; used by: SampleType" in out
     # StandardMissingValueCodes is not a field enum -> no "used by".
     assert "StandardMissingValueCodes:  # 2 of 2 enums\n" in out
 
@@ -279,7 +309,7 @@ def test_annotate_enum_usage_dedup_and_cap():
 
 def test_annotate_enum_values_off_by_default(schema_yaml):
     # Default output: no value comment after the enum range.
-    assert "range: SalivaBloodEnum\n" in schema_yaml
+    assert "range: SampleTypeEnum\n" in schema_yaml
     assert "# 0=Saliva" not in schema_yaml
 
 
@@ -289,7 +319,7 @@ def test_annotate_enum_values_adds_capped_comment():
         rows,
         EmitOptions(schema_name="s", class_name="Record", annotate_enum_values=True),
     )
-    assert "- range: SalivaBloodEnum  # 0=Saliva | 1=Blood" in out
+    assert "- range: SampleTypeEnum  # 0=Saliva | 1=Blood" in out
     # StandardMissingValueCodes is not a field enum -> never annotated.
     assert "range: StandardMissingValueCodes  #" not in out
 

--- a/converter/tests/test_parse.py
+++ b/converter/tests/test_parse.py
@@ -1,0 +1,90 @@
+"""Tests for the enumeration / missing-value-codes cell parser.
+
+The valid examples are drawn from the specification's own worked examples so the
+parser is checked against the authoritative source.
+"""
+
+import pytest
+
+from radx_dd_converter.grammar import (
+    EnumItem,
+    ParseError,
+    parse_enumeration,
+    parse_missing_value_codes,
+)
+
+
+@pytest.mark.parametrize(
+    "cell, expected",
+    [
+        # Whitespace around | and = is insignificant; all three are equivalent.
+        (
+            '"0"=[Saliva] | "1"=[Blood]',
+            [EnumItem("0", "Saliva"), EnumItem("1", "Blood")],
+        ),
+        (
+            '"0"=[Saliva]|"1"=[Blood]',
+            [EnumItem("0", "Saliva"), EnumItem("1", "Blood")],
+        ),
+        (
+            '"0" = [Saliva] | "1" = [Blood]',
+            [EnumItem("0", "Saliva"), EnumItem("1", "Blood")],
+        ),
+        # String values equal to their labels.
+        (
+            '"Saliva"=[Saliva] | "Blood"=[Blood]',
+            [EnumItem("Saliva", "Saliva"), EnumItem("Blood", "Blood")],
+        ),
+        # Multi-word labels with spaces.
+        (
+            '"RBC" = [Red Blood Cells] | "WBC" = [White Blood Cells]',
+            [
+                EnumItem("RBC", "Red Blood Cells"),
+                EnumItem("WBC", "White Blood Cells"),
+            ],
+        ),
+        # A single pair, negative-signed value (as used by missing-value codes).
+        ('"-9999"=[Reason Unknown]', [EnumItem("-9999", "Reason Unknown")]),
+    ],
+)
+def test_parse_enumeration_valid(cell, expected):
+    assert parse_enumeration(cell) == expected
+
+
+def test_parse_enumeration_with_full_iri_and_obo_id():
+    cell = (
+        '"0"=[Saliva](http://purl.obolibrary.org/obo/UBERON_0001836) '
+        '| "1"=[Blood](UBERON:0000178)'
+    )
+    assert parse_enumeration(cell) == [
+        EnumItem("0", "Saliva", "http://purl.obolibrary.org/obo/UBERON_0001836"),
+        EnumItem("1", "Blood", "UBERON:0000178"),
+    ]
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t", None])
+def test_parse_enumeration_blank_is_empty(blank):
+    assert parse_enumeration(blank) == []
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "0=[Saliva]",  # value not quoted
+        '"0"=Saliva',  # label not bracketed
+        '"0"=[Saliva] | ',  # trailing empty item
+        '"0"=[Saliva] || "1"=[Blood]',  # empty middle item
+        "garbage",  # no structure at all
+    ],
+)
+def test_parse_enumeration_malformed_raises(bad):
+    with pytest.raises(ParseError):
+        parse_enumeration(bad)
+
+
+def test_missing_value_codes_uses_same_grammar():
+    cell = '"-9999"=[Reason Unknown] | "-9980"=[Not Sent to Data Hub]'
+    assert parse_missing_value_codes(cell) == [
+        EnumItem("-9999", "Reason Unknown"),
+        EnumItem("-9980", "Not Sent to Data Hub"),
+    ]

--- a/converter/tests/test_reader.py
+++ b/converter/tests/test_reader.py
@@ -1,0 +1,94 @@
+"""Tests for the data dictionary CSV reader."""
+
+import io
+from pathlib import Path
+
+import pytest
+
+from radx_dd_converter import ReadError, read_data_dictionary
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _read_str(text: str):
+    return read_data_dictionary(io.StringIO(text))
+
+
+def test_reads_fixture_in_order():
+    rows = read_data_dictionary(FIXTURES / "sample.csv")
+    assert [r.id for r in rows] == ["PartId", "SampleType", "Symptoms"]
+    # Row order is significant and must be preserved.
+    assert rows[0].get("Label") == "Participant Id"
+    assert rows[0].get("Pattern") == r"^[NP](\d+)$"
+
+
+def test_quoted_enumeration_cell_survives_rfc4180():
+    rows = read_data_dictionary(FIXTURES / "sample.csv")
+    sample_type = rows[1]
+    # The doubled quotes in the CSV collapse to a single cell containing the
+    # enumeration grammar verbatim.
+    assert sample_type.get("Enumeration") == (
+        '"0"=[Saliva](UBERON:0001836) | "1"=[Blood](UBERON:0000178)'
+    )
+
+
+def test_blank_optional_cell_is_empty_string():
+    rows = _read_str(
+        "Id,Label,Datatype,Description\n"
+        "A,Label A,string,\n"
+    )
+    assert rows[0].get("Description") == ""
+
+
+def test_utf8_bom_is_stripped_from_first_header():
+    # Excel's "CSV UTF-8" writes a BOM; the Id column must still be found.
+    rows = _read_str("﻿Id,Label,Datatype\nA,Label A,string\n")
+    assert rows[0].id == "A"
+
+
+def test_extra_columns_are_preserved():
+    rows = _read_str(
+        "Id,Label,Datatype,CustomThing\n"
+        "A,Label A,string,hello\n"
+    )
+    assert rows[0].extra_columns == ("CustomThing",)
+    assert rows[0].get("CustomThing") == "hello"
+
+
+def test_wholly_blank_lines_are_skipped():
+    rows = _read_str(
+        "Id,Label,Datatype\n"
+        "A,Label A,string\n"
+        ",,\n"
+        "B,Label B,integer\n"
+    )
+    assert [r.id for r in rows] == ["A", "B"]
+
+
+def test_missing_required_header_raises():
+    with pytest.raises(ReadError, match="Missing required column"):
+        _read_str("Id,Label\nA,Label A\n")
+
+
+def test_blank_required_cell_raises():
+    with pytest.raises(ReadError, match="required column 'Datatype' is blank"):
+        _read_str("Id,Label,Datatype\nA,Label A,\n")
+
+
+def test_duplicate_id_raises():
+    with pytest.raises(ReadError, match="duplicate Id 'A'"):
+        _read_str(
+            "Id,Label,Datatype\n"
+            "A,Label A,string\n"
+            "A,Label A2,integer\n"
+        )
+
+
+def test_duplicate_header_raises():
+    with pytest.raises(ReadError, match="Duplicate column header"):
+        _read_str("Id,Label,Datatype,Label\nA,x,string,y\n")
+
+
+def test_empty_file_raises():
+    with pytest.raises(ReadError, match="empty"):
+        _read_str("")

--- a/converter/tests/test_reader.py
+++ b/converter/tests/test_reader.py
@@ -84,6 +84,21 @@ def test_duplicate_id_raises():
         )
 
 
+def test_allow_duplicates_keeps_first_skips_rest():
+    rows = read_data_dictionary(
+        io.StringIO(
+            "Id,Label,Datatype\n"
+            "A,First A,string\n"
+            "B,Label B,integer\n"
+            "A,Second A,integer\n"
+        ),
+        allow_duplicates=True,
+    )
+    # First occurrence kept, later duplicate skipped; order preserved.
+    assert [r.id for r in rows] == ["A", "B"]
+    assert rows[0].get("Label") == "First A"
+
+
 def test_duplicate_header_raises():
     with pytest.raises(ReadError, match="Duplicate column header"):
         _read_str("Id,Label,Datatype,Label\nA,x,string,y\n")

--- a/converter/tests/test_tables.py
+++ b/converter/tests/test_tables.py
@@ -1,0 +1,58 @@
+"""Tests for the constant tables: standard missing-value codes and units."""
+
+import pytest
+
+from radx_dd_converter import (
+    STANDARD_MISSING_VALUE_CODES,
+    UnitOfMeasure,
+    lookup_unit,
+)
+
+
+# --- Standard missing-value codes ------------------------------------------
+
+def test_standard_codes_count():
+    # The specification defines exactly 25 standard codes.
+    assert len(STANDARD_MISSING_VALUE_CODES) == 25
+
+
+def test_standard_codes_are_unique():
+    values = [c.value for c in STANDARD_MISSING_VALUE_CODES]
+    assert len(set(values)) == len(values)
+
+
+def test_standard_codes_spot_check():
+    by_value = {c.value: c.label for c in STANDARD_MISSING_VALUE_CODES}
+    assert by_value["-9999"] == "Reason Unknown"
+    assert by_value["-9980"] == "Not Sent to Data Hub"
+    assert by_value["-9946"] == "Other Unpresented Reason Not Specified"
+
+
+# --- Unit table ------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "raw, expected_name, expected_symbol",
+    [
+        ("mm", "millimeter", "mm"),
+        ("millimeter", "millimeter", "mm"),
+        ("MILLIMETER", "millimeter", "mm"),  # case-insensitive
+        (" mL ", "milliliter", "mL"),  # surrounding whitespace ignored
+        ("°C", "degrees Celsius", "°C"),
+        ("mol/L", "moles per liter", "mol/L"),
+    ],
+)
+def test_lookup_by_name_or_symbol(raw, expected_name, expected_symbol):
+    u = lookup_unit(raw)
+    assert isinstance(u, UnitOfMeasure)
+    assert u.descriptive_name == expected_name
+    assert u.symbol == expected_symbol
+
+
+def test_lookup_populates_ucum_code():
+    assert lookup_unit("degrees Celsius").ucum_code == "Cel"
+    assert lookup_unit("mm").ucum_code == "mm"
+
+
+@pytest.mark.parametrize("unknown", ["parsecs", "widgets", "", "   ", None])
+def test_lookup_unknown_returns_none(unknown):
+    assert lookup_unit(unknown) is None

--- a/converter/tests/test_terms.py
+++ b/converter/tests/test_terms.py
@@ -1,0 +1,32 @@
+"""Tests for the Terms cell tokeniser."""
+
+import pytest
+
+from radx_dd_converter.grammar import parse_terms
+
+
+@pytest.mark.parametrize(
+    "cell, expected",
+    [
+        ("UBERON:0001836", ["UBERON:0001836"]),
+        (
+            "UBERON:0001836 UBERON:0000178",
+            ["UBERON:0001836", "UBERON:0000178"],
+        ),
+        (
+            "http://purl.obolibrary.org/obo/UBERON_0001836",
+            ["http://purl.obolibrary.org/obo/UBERON_0001836"],
+        ),
+        # Non-breaking space (U+00A0) is an allowed separator.
+        ("UBERON:1 UBERON:2", ["UBERON:1", "UBERON:2"]),
+        # Newline is an allowed separator; surrounding whitespace ignored.
+        ("  UBERON:1\nUBERON:2  ", ["UBERON:1", "UBERON:2"]),
+    ],
+)
+def test_parse_terms(cell, expected):
+    assert parse_terms(cell) == expected
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\n", None])
+def test_parse_terms_blank_is_empty(blank):
+    assert parse_terms(blank) == []

--- a/converter/tests/test_terms_lookup.py
+++ b/converter/tests/test_terms_lookup.py
@@ -1,0 +1,62 @@
+"""Tests for term-name annotation.
+
+The OLS4 network lookup itself is not exercised here (tests stay offline); we
+test the CURIE->IRI expansion and the YAML comment-annotation pass, which are
+the parts with logic worth pinning down.
+"""
+
+from radx_dd_converter.emit import _annotate_term_lines
+from radx_dd_converter.terms_lookup import _to_iri
+
+
+def test_to_iri_expands_obo_curie():
+    assert _to_iri("MONDO:0004979") == "http://purl.obolibrary.org/obo/MONDO_0004979"
+    assert _to_iri("NCIT:C25150") == "http://purl.obolibrary.org/obo/NCIT_C25150"
+
+
+def test_to_iri_passes_through_full_iri():
+    iri = "http://purl.obolibrary.org/obo/UBERON_0001836"
+    assert _to_iri(iri) == iri
+
+
+def test_to_iri_rejects_non_curie():
+    assert _to_iri("just text") is None
+    assert _to_iri("has/slash:0001") is None
+
+
+def test_annotate_meaning_and_list_lines():
+    text = (
+        "enums:\n"
+        "  E:\n"
+        "    permissible_values:\n"
+        "      '0':\n"
+        "        meaning: UBERON:0001836\n"
+        "attributes:\n"
+        "  age:\n"
+        "    related_mappings:\n"
+        "    - PATO:0000011\n"
+    )
+    out = _annotate_term_lines(
+        text, {"UBERON:0001836": "saliva", "PATO:0000011": "age"}
+    )
+    assert "meaning: UBERON:0001836  # saliva" in out
+    assert "- PATO:0000011  # age" in out
+
+
+def test_annotate_leaves_block_scalar_text_untouched():
+    text = (
+        "    description: |\n"
+        "      A sentence mentioning PATO:0000011 inline.\n"
+    )
+    out = _annotate_term_lines(text, {"PATO:0000011": "age"})
+    assert "inline.  #" not in out
+    assert out == text  # nothing changed
+
+
+def test_annotate_skips_unknown_terms_and_existing_comments():
+    text = "    - PATO:0000011  # already commented\n    - NCIT:C1\n"
+    out = _annotate_term_lines(text, {"PATO:0000011": "age"})
+    # existing comment preserved, not doubled
+    assert out.count("#") == 1
+    # NCIT:C1 not in labels -> untouched
+    assert "NCIT:C1\n" in out

--- a/converter/tests/test_terms_lookup.py
+++ b/converter/tests/test_terms_lookup.py
@@ -5,8 +5,15 @@ test the CURIE->IRI expansion and the YAML comment-annotation pass, which are
 the parts with logic worth pinning down.
 """
 
+import pytest
+
 from radx_dd_converter.emit import _annotate_term_lines
-from radx_dd_converter.terms_lookup import _to_iri
+from radx_dd_converter.terms_lookup import (
+    LookupError_,
+    _curie_prefix,
+    _to_iri,
+    lookup_labels,
+)
 
 
 def test_to_iri_expands_obo_curie():
@@ -60,3 +67,25 @@ def test_annotate_skips_unknown_terms_and_existing_comments():
     assert out.count("#") == 1
     # NCIT:C1 not in labels -> untouched
     assert "NCIT:C1\n" in out
+
+
+# --- resolver selection (offline) ------------------------------------------
+
+def test_curie_prefix():
+    assert _curie_prefix("MONDO:0004979") == "MONDO"
+    assert _curie_prefix("http://purl.obolibrary.org/obo/MONDO_0004979") is None
+
+
+def test_bioportal_requires_apikey():
+    with pytest.raises(LookupError_, match="API key"):
+        lookup_labels(["MONDO:0004979"], resolver="bioportal")
+
+
+def test_unknown_resolver_raises():
+    with pytest.raises(LookupError_, match="Unknown resolver"):
+        lookup_labels(["MONDO:0004979"], resolver="nope")
+
+
+def test_empty_terms_returns_empty_without_network():
+    # No terms -> no lookups attempted, returns {} even for bioportal w/o key.
+    assert lookup_labels([], resolver="ols4") == {}

--- a/linkml/CONVERTER_PLAN.md
+++ b/linkml/CONVERTER_PLAN.md
@@ -34,7 +34,7 @@ LinkML's bracketed `[ | ]`).
 | `Description` | `description:` | |
 | `Section` | declared `subset` + slot `in_subset:` | See "Section grouping"; annotation only as fallback |
 | `Cardinality` | `multivalued: true` | Only when value is `multiple`; else single-valued |
-| `Terms` | `slot_uri:` (first) + `exact_mappings:` (rest) | CURIEs need prefixes registered in output |
+| `Terms` | `related_mappings:` (all terms) | Subject-matter annotations, not the slot's predicate URI; CURIE prefixes registered in output |
 | `Datatype` | `range:` | Via the datatype map below |
 | `Pattern` | `pattern:` | Emitted verbatim (XSD-regex dialect) |
 | `Unit` | native `unit:` (UnitOfMeasure), lookup-assisted | See "Unit mapping"; `annotations.unit_raw` always kept |

--- a/linkml/CONVERTER_PLAN.md
+++ b/linkml/CONVERTER_PLAN.md
@@ -1,11 +1,16 @@
-# RADx Data Dictionary → LinkML Schema Converter — Plan
+# RADx Data Dictionary → LinkML Schema Converter — Design
+
+> **Status:** Implemented in [`../converter/`](../converter/) as the
+> `radx-dd-to-linkml` tool. This document is the design record: it explains what
+> the converter does and why the mapping decisions were made. Where the code and
+> this document ever disagree, the code (and its tests) is authoritative.
 
 ## Goal
 
-A Python tool that reads a RADx data dictionary in CSV format and emits a
-**LinkML schema** describing the *target datafile* that the dictionary
-documents. Each data element (row) becomes a **slot**; the datafile as a whole
-becomes a **class** (`Record`).
+The converter reads a RADx data dictionary in CSV format and emits a **LinkML
+schema** describing the *target datafile* that the dictionary documents. Each
+data element (row) becomes a **slot**; the datafile as a whole becomes a
+**class** (default name `Record`).
 
 This is *metamodeling*: the dictionary is metadata about a datafile, and the
 output schema is a formal description of that datafile's structure, suitable for
@@ -221,8 +226,14 @@ radx_dd_converter/
   cli.py           # argparse entry point
 tests/
   fixtures/        # small CSVs incl. the spec's own worked examples
-  test_reader.py test_parse.py test_datatypes.py test_emit.py test_e2e.py
+  test_reader.py test_parse.py test_terms.py test_datatypes.py
+  test_tables.py test_emit.py test_cli.py
 ```
+
+The emitter also post-processes its YAML for readability (literal `|` blocks for
+multi-line text, section-header comments, blank lines between entries, redundant
+`name:`/`text:` keys dropped, `annotations` last); a round-trip test asserts this
+never alters the schema content.
 
 **Two layers, cleanly separated:**
 1. **Parser layer** (`grammar/`) — turns cell mini-grammars into Python objects.
@@ -239,10 +250,12 @@ tests/
 - Unknown / mis-cased datatype name → error listing the offending value + row.
 - Malformed `Enumeration` / `MissingValueCodes` cell → parser error with the
   cell content and row index.
-- Duplicate `Id`, or an `Alias` colliding with an `Id`/alias → error (the spec's
-  uniqueness rule).
-- Unresolvable CURIE prefix in `Terms`/enum `meaning` → warn, emit the CURIE
-  anyway, and add the prefix as a `TODO` annotation.
+- Duplicate `Id` → error naming both lines. (Alias-vs-Id/alias uniqueness across
+  the whole dictionary is specified but not yet enforced by the reader; noted as
+  future work.)
+- Non-OBO CURIE prefix in `Terms`/enum `meaning` → the prefix is registered with
+  a best-effort OBO expansion and a warning is logged (shown with `--verbose`),
+  rather than failing.
 
 ## Validation strategy
 
@@ -272,8 +285,8 @@ tests/
    dictionaries have no standard metadata row).
 
 3. **Packaging (decided).** An installable Python package living in this
-   repository under [`converter/`](../converter/), with a `radx-dd-to-linkml`
-   console script (added once the CLI layer exists).
+   repository under [`converter/`](../converter/), exposing the
+   `radx-dd-to-linkml` console script.
 
 ## Future work (not v1)
 
@@ -300,6 +313,9 @@ Future items:
   (rewrite RADx bare-pipe cells to `[a|b|c]`, or a custom loader) before
   `linkml-convert` can be used. It is not a no-op.
 - Reverse direction: LinkML schema → RADx data dictionary CSV.
+- **Alias uniqueness enforcement.** The reader rejects a duplicate `Id`, but does
+  not yet check that an `Alias` never collides with another record's `Id` or
+  alias (the spec's cross-dictionary uniqueness rule).
 
 ## Tested note: LinkML in-cell multi-value behavior (LinkML 1.11)
 

--- a/linkml/CONVERTER_PLAN.md
+++ b/linkml/CONVERTER_PLAN.md
@@ -252,17 +252,28 @@ tests/
   schema in-test and assert 0 errors — the converter must always emit a valid
   schema.
 
-## Open questions / decisions still to make
+## Resolved decisions
 
-1. **Prefixes for `Terms`/`meaning` CURIEs.** OBO ids expand deterministically
-   (`MONDO:0004979` → `http://purl.obolibrary.org/obo/MONDO_0004979`). Do we
-   (a) always expand to full IRIs, or (b) register prefixes in the output
-   schema's `prefixes:` and keep CURIEs? (Leaning (b), with OBO expansion as a
-   known prefix map.)
-2. **Class name / schema id.** Derived from CLI flags, filename, or a dictionary
-   metadata row? (Start: CLI flags with filename fallback.)
-3. **Packaging.** Standalone script vs. installable package with an entry point.
-   Where does it live — this repo, or a sibling repo?
+1. **Prefixes for `Terms`/`meaning` CURIEs (decided).** Emit compact ids
+   (`UBERON:0001836`) **as-is** and register their prefixes in the output
+   schema's `prefixes:` block, rather than expanding to full IRIs. OBO Foundry
+   prefixes are auto-registered using the deterministic OBO rule
+   (`IDSPACE:LOCALID` → `http://purl.obolibrary.org/obo/IDSPACE_LOCALID`), so any
+   `IDSPACE:` prefix seen in the input maps to
+   `http://purl.obolibrary.org/obo/IDSPACE_`. Full IRIs are emitted unchanged. A
+   non-OBO CURIE whose prefix cannot be resolved is kept as-is and a warning is
+   logged (its prefix is left for the user to declare).
+
+2. **Schema `id` / `name` / root class name (decided).** Taken from CLI flags
+   (`--id`, `--name`, `--class-name`); when a flag is omitted, derived from the
+   input CSV filename (e.g. `patient_data.csv` → name `patient_data`, id under a
+   default base, class `PatientData`). The default root class name, when nothing
+   else is given, is **`Record`**. No dictionary metadata row is assumed (RADx
+   dictionaries have no standard metadata row).
+
+3. **Packaging (decided).** An installable Python package living in this
+   repository under [`converter/`](../converter/), with a `radx-dd-to-linkml`
+   console script (added once the CLI layer exists).
 
 ## Future work (not v1)
 


### PR DESCRIPTION
Adds a Python tool, `radx-dd-to-linkml`, that converts a RADx data dictionary CSV into a LinkML schema describing the target datafile (one slot per data element). Lives in a new `converter/` package; implements the design in `linkml/CONVERTER_PLAN.md`.

> Note: the branch name (`converter-parser-layer`) predates the full scope — this PR is the complete converter, not just the parser.

## Pipeline

- **`grammar/`** — Lark parser for the in-cell mini-grammars (`Enumeration`/`MissingValueCodes` `"v"=[label](iri)` syntax) plus the `Terms` tokenizer. The one piece stock LinkML tooling cannot provide.
- **`reader.py`** — RFC-4180 CSV → ordered `Row`s; header validation, duplicate-`Id` detection, UTF-8 BOM handling.
- **`datatypes.py`** — RADx/XSD datatype name → LinkML built-in range or emitted custom `type`. Covers all 47 allowable names (test-checked against the schema's `DatatypeEnum`).
- **`missing_values.py` / `units.py`** — the 25 standard missing-value codes and the spec's unit table.
- **`emit.py`** — assembles a `linkml_runtime` `SchemaDefinition` and dumps readable YAML.
- **`cli.py`** — `radx-dd-to-linkml IN.csv -o OUT.yaml`, with filename-derived name/id/class defaults.

## Mapping (see CONVERTER_PLAN.md for rationale)

- `Enumeration` → generated enum wired via slot `any_of` with a shared `StandardMissingValueCodes` enum (codes augment, not replace); underlying `value_datatype` preserved; identical enumerations de-duplicated.
- `Datatype` → built-in range or a self-contained custom type (`date_mdy`, `timestamp`, `gYearMonth`, …).
- `Section` → declared `subset` + `in_subset`; `Unit` → native `unit:` (lookup-assisted, raw preserved); `Terms` → `related_mappings`; `Provenance` → `source:`/annotation. CURIEs kept with OBO prefixes auto-registered.

## Readable output (always on)

- Multi-line descriptions as literal `|` blocks; leading/trailing blank lines and per-line trailing whitespace stripped.
- Section-header comments and blank lines between entries; redundant `name:`/`text:` keys dropped; `annotations` last; slot keys ordered `title`, `description`, `range` first.
- **`# n of m` counters** on every entry, labelled in RADx terms: `# 1 of 133 data elements`, `# 1 of 16 enums`, `# 1 of 14 sections`, `# 1 of 1 class`.

## Optional annotations (flags)

- `--annotate-terms` — look up ontology term names and add them as comments (`- MONDO:0004979  # asthma`). Resolver selectable with `--resolver {ols4,bioportal}` (OLS4 default, open; BioPortal needs `BIOPORTAL_API_KEY`). Concurrent, de-duplicated, skip-on-failure.
- `--annotate-enum-values` — after a field enum `range:`, list its `value=label` pairs (capped): `- range: SampleTypeEnum  # 0=Saliva | 1=Blood`.
- `--annotate-enum-usage` — on each field enum definition, list the data elements that use it (capped): `NihDisabilityEnum:  # used by: nih_disability | … (+105 more)`.
- `--allow-duplicates` — tolerate repeated `Id`s (keep first, skip rest, warn) instead of failing.

## Testing

124 tests, including an end-to-end test that lints the generated schema (0 errors). Verified on two real dictionaries (133 and 888 data elements) and via a clean-venv install. Example inputs/outputs are kept local (gitignored) as they may contain unpublished study metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
