### PR TITLE
Converter README how-to rewrite (follow-up to #19)

### DIFF
--- a/converter/README.md
+++ b/converter/README.md
@@ -10,7 +10,7 @@ or transform with the wider LinkML tool ecosystem.
 
 From the repository root:
 
-```sh
+```
 pip install ./converter
 ```
 
@@ -21,13 +21,13 @@ This installs the `radx-dd-to-linkml` command and its dependencies
 
 Convert a data dictionary to a schema file:
 
-```sh
+```
 radx-dd-to-linkml my_dictionary.csv -o my_schema.yaml
 ```
 
 With no `-o`, the schema is written to standard output, so you can pipe it:
 
-```sh
+```
 radx-dd-to-linkml my_dictionary.csv | less
 ```
 
@@ -37,7 +37,7 @@ By default the schema's name, id, and root class are derived from the input
 filename (`patient_data.csv` → name `patient_data`, class `PatientData`).
 Override any of them:
 
-```sh
+```
 radx-dd-to-linkml my_dictionary.csv -o my_schema.yaml \
     --name my_data --id https://example.org/my_data --class-name Record
 ```
@@ -61,7 +61,7 @@ resolved is left as a bare identifier. Choose the lookup service with
 - `bioportal` — requires an API key via the `BIOPORTAL_API_KEY` environment
   variable (or `--bioportal-apikey`).
 
-```sh
+```
 radx-dd-to-linkml my_dictionary.csv -o out.yaml --annotate-terms
 BIOPORTAL_API_KEY=… radx-dd-to-linkml my_dictionary.csv -o out.yaml \
     --annotate-terms --resolver bioportal
@@ -168,7 +168,7 @@ print(emit_schema(rows, EmitOptions(schema_name="my_data", class_name="Record"))
 The design decisions behind the mapping are recorded in
 [`../linkml/CONVERTER_PLAN.md`](../linkml/CONVERTER_PLAN.md). To run the tests:
 
-```sh
+```
 pip install -e "./converter[test]"
 pytest converter
 ```

--- a/converter/README.md
+++ b/converter/README.md
@@ -1,110 +1,160 @@
 # RADx Data Dictionary → LinkML Converter
 
-A Python tool that converts a RADx data dictionary CSV into a LinkML schema
-describing the target datafile. See [`../linkml/CONVERTER_PLAN.md`](../linkml/CONVERTER_PLAN.md)
-for the design.
+`radx-dd-to-linkml` converts a [RADx data dictionary](../radx-data-dictionary-specification.md)
+CSV into a [LinkML](https://linkml.io) schema. The data dictionary *describes* a
+datafile; the generated schema is a formal, machine-processable description of
+that datafile that you can validate data against, generate documentation from,
+or transform with the wider LinkML tool ecosystem.
 
-## Status
+## Install
 
-Feature-complete for v1. Components:
+From the repository root:
 
-- **Reader** (`radx_dd_converter/reader.py`) — `read_data_dictionary` parses a
-  data dictionary CSV per RFC 4180, validates the header (required columns
-  `Id`/`Label`/`Datatype`, duplicate detection), and returns ordered `Row`
-  objects (row order is significant). Errors on blank required cells and
-  duplicate `Id`s; preserves extra (non-canonical) columns.
-- **Parser layer** (`radx_dd_converter/grammar/`) — parses the in-cell
-  mini-grammars used by RADx data dictionaries:
-  - `parse_enumeration` / `parse_missing_value_codes` — the
-    `"value"=[label](iri) | ...` syntax, driven by a Lark grammar
-    (`grammar/enumeration.lark`) that mirrors the EBNF in the specification.
-  - `parse_terms` — splits a `Terms` cell into IRI/CURIE tokens.
-- **Datatype mapping** (`radx_dd_converter/datatypes.py`) — `resolve_datatype`
-  maps a RADx/XSD datatype name to either a LinkML built-in range or a
-  `CustomType` the emitter must add to the schema's `types:` block. Covers all
-  47 allowable names (a test checks this against the schema's `DatatypeEnum`);
-  case-sensitive, unknown names raise.
-- **Constant tables** — `missing_values.py` holds the 25 standard
-  missing-value codes (stored as the spec's verbatim default string and parsed
-  by the converter's own parser); `units.py` provides `lookup_unit`, mapping a
-  raw `Unit` cell (by name or symbol) to a structured `UnitOfMeasure`.
-- **Emitter** (`radx_dd_converter/emit.py`) — `emit_schema(rows, options)`
-  assembles rows + parsed cells into a `linkml_runtime` `SchemaDefinition` and
-  dumps readable YAML (multi-line descriptions as literal `|` blocks; section
-  comments and blank lines between slots/enums/types). Implements the full
-  mapping: `Datatype` → range / custom type,
-  `Enumeration` → generated enum wired via slot `any_of` with the shared
-  `StandardMissingValueCodes` (and per-field codes), `Provenance` →
-  `source:`/annotation, `Section` → `in_subset`, `Unit` → native `unit:`
-  (lookup-assisted, raw preserved), CURIEs kept with OBO prefixes auto-
-  registered. A test lints the generated schema and asserts zero errors.
+```sh
+pip install ./converter
+```
 
-- **CLI** (`radx_dd_converter/cli.py`) — the `radx-dd-to-linkml` console script
-  ties the pipeline together: read CSV → emit schema → write YAML. Schema
-  name/id/class default from the input filename and can be overridden with
-  flags. Reports read/parse/datatype errors cleanly (no traceback). A duplicate
-  `Id` is fatal by default; `--allow-duplicates` keeps the first occurrence,
-  skips later ones, and warns.
+This installs the `radx-dd-to-linkml` command and its dependencies
+(`linkml`, `lark`).
 
-The converter is feature-complete for v1.
+## Use it
 
-## Usage (CLI)
+Convert a data dictionary to a schema file:
 
 ```sh
 radx-dd-to-linkml my_dictionary.csv -o my_schema.yaml
-# override the derived identifiers:
-radx-dd-to-linkml my_dictionary.csv -o my_schema.yaml \
-    --name my_data --id https://example.org/my_data --class-name Record
-# default output is stdout:
-radx-dd-to-linkml my_dictionary.csv | head
-# look up ontology term names (via OLS4) and add them as YAML comments
-# (requires network; unresolved terms are skipped):
-radx-dd-to-linkml my_dictionary.csv -o my_schema.yaml --annotate-terms
 ```
 
-With `--annotate-terms`, ontology CURIEs are annotated with their labels, e.g.
-`- MONDO:0004979  # asthma`. Lookups are de-duplicated, run concurrently, and any
-term that cannot be resolved is left as a bare CURIE.
-
-The resolver is selectable with `--resolver`:
-
-- `ols4` (default) — the EBI Ontology Lookup Service; open, no key required.
-- `bioportal` — BioPortal; requires an API key via `BIOPORTAL_API_KEY` (or
-  `--bioportal-apikey`).
+With no `-o`, the schema is written to standard output, so you can pipe it:
 
 ```sh
-radx-dd-to-linkml my_dictionary.csv -o out.yaml --annotate-terms --resolver ols4
-BIOPORTAL_API_KEY=... radx-dd-to-linkml my_dictionary.csv -o out.yaml \
+radx-dd-to-linkml my_dictionary.csv | less
+```
+
+### Naming the schema
+
+By default the schema's name, id, and root class are derived from the input
+filename (`patient_data.csv` → name `patient_data`, class `PatientData`).
+Override any of them:
+
+```sh
+radx-dd-to-linkml my_dictionary.csv -o my_schema.yaml \
+    --name my_data --id https://example.org/my_data --class-name Record
+```
+
+### Adding ontology term names
+
+Data dictionaries reference ontology terms by identifier (e.g. `MONDO:0004979`).
+With `--annotate-terms`, the converter looks each up and adds its human-readable
+name as a comment, so the schema is easier to read:
+
+```yaml
+related_mappings:
+- MONDO:0004979  # asthma
+```
+
+Lookups require network access and are de-duplicated; any term that cannot be
+resolved is left as a bare identifier. Choose the lookup service with
+`--resolver`:
+
+- `ols4` (default) — the EBI Ontology Lookup Service; open, no key required.
+- `bioportal` — requires an API key via the `BIOPORTAL_API_KEY` environment
+  variable (or `--bioportal-apikey`).
+
+```sh
+radx-dd-to-linkml my_dictionary.csv -o out.yaml --annotate-terms
+BIOPORTAL_API_KEY=… radx-dd-to-linkml my_dictionary.csv -o out.yaml \
     --annotate-terms --resolver bioportal
 ```
 
-`--annotate-enum-values` adds a comment after each field enum's `range:` listing
-its `value=label` pairs (capped, with a `(+N more)` overflow), so the allowed
-values are visible at the point of use without scrolling to the `enums:` section:
+### Other options
 
-```yaml
-- range: SampleTypeEnum  # 0=Saliva | 1=Blood
+| Option | Effect |
+| --- | --- |
+| `--annotate-enum-values` | After a field enum's `range:`, add a comment listing its `value=label` pairs. |
+| `--allow-duplicates` | Tolerate a repeated `Id` (keep the first, skip later ones) instead of failing. |
+| `-v`, `--verbose` | Show warnings (unresolved term lookups, non-OBO prefixes, skipped duplicates). |
+
+Run `radx-dd-to-linkml --help` for the complete list.
+
+## What gets generated
+
+The output is a LinkML schema with a single class — the *datafile* — whose
+**slots are the data dictionary's data elements, in order**. Each dictionary
+column maps to a LinkML feature of the slot:
+
+| Data dictionary column | In the generated schema |
+| --- | --- |
+| `Id` | slot name |
+| `Label` | slot `title` |
+| `Description` | slot `description` |
+| `Datatype` | slot `range` (a LinkML built-in, or a generated custom `type` for datatypes like `date_mdy` / `timestamp`) |
+| `Pattern` | slot `pattern` |
+| `Cardinality` | `multivalued: true` when `multiple` |
+| `Enumeration` | a generated enum, referenced from the slot (see below) |
+| `Unit` | native `unit:` (matched to a known unit where possible; the raw value is always kept) |
+| `Terms` | `related_mappings` (ontology CURIEs; their prefixes are declared in the schema) |
+| `Aliases` / `Examples` | slot `aliases` / `examples` |
+| `Provenance` / `SeeAlso` | slot `source` / `see_also` |
+| `Section` | a LinkML `subset`, referenced from the slot via `in_subset` |
+| `MissingValueCodes` | folded into the enum union (see below) |
+
+### Enumerations and missing-value codes
+
+A data element with an `Enumeration` becomes a generated enum, and the slot
+accepts **either** one of that enum's values **or** a standard RADx
+missing-value code. For example, this data dictionary row:
+
+```csv
+Id,Label,Datatype,Enumeration
+sample_type,Sample Type,integer,"""0""=[Saliva] | ""1""=[Blood]"
 ```
 
-Comment blocks are placed above entries (always on) to make the schema easier
-to scan:
-
-- **Field enums** and **sections** get a 3-line block: its number, how many data
-  elements use it, and the referencing ids (capped) — useful for spotting a
-  shared enum or a large section.
-- **Data elements** get a 1-line block: `# Data element n of m`.
+produces (comment lines elided for brevity):
 
 ```yaml
-# Enum 8 of 16
-# Used by 111 data elements
-# nih_disability | nih_deaf | nih_blind | ... (+105 more)
-NoYesOtherEtcEnum:
+classes:
+  Record:
+    attributes:
+      sample_type:
+        title: Sample Type
+        any_of:
+        - range: SampleTypeEnum
+        - range: StandardMissingValueCodes
+        annotations:
+          value_datatype: integer
+enums:
+  SampleTypeEnum:
+    permissible_values:
+      '0':
+        title: Saliva
+      '1':
+        title: Blood
 ```
 
-The shared `StandardMissingValueCodes` enum is always emitted last in the
-`enums:` section.
+Identical enumerations are collapsed into one shared enum. An enum used by a
+single data element is named after it (`SampleTypeEnum` above); an enum shared
+by several is named after its values instead (e.g. a reused `No`/`Yes` set
+becomes `NoYesEnum`), since no single field owns it. The 25 standard
+missing-value codes are emitted once as `StandardMissingValueCodes`.
 
-## Usage (library)
+### Readability
+
+The generated YAML is formatted to be read by humans as well as tools:
+multi-line descriptions use block (`|`) style, and each enum, section, and data
+element carries a short comment block noting its position and (for enums and
+sections) which data elements reference it.
+
+## Worked examples
+
+The [`examples/`](examples/) folder contains real data dictionaries and the
+schemas produced from them: [`gcb.dd.csv`](examples/gcb.dd.csv) →
+[`gcb.yaml`](examples/gcb.yaml), and [`rad.dd.csv`](examples/rad.dd.csv) →
+[`rad.yaml`](examples/rad.yaml).
+
+## Library use
+
+The pipeline is also importable:
 
 ```python
 from radx_dd_converter import read_data_dictionary, emit_schema, EmitOptions
@@ -113,10 +163,12 @@ rows = read_data_dictionary("my_dictionary.csv")
 print(emit_schema(rows, EmitOptions(schema_name="my_data", class_name="Record")))
 ```
 
-## Development
+## Design and development
+
+The design decisions behind the mapping are recorded in
+[`../linkml/CONVERTER_PLAN.md`](../linkml/CONVERTER_PLAN.md). To run the tests:
 
 ```sh
-# from the repository root, using the project's virtualenv
-.venv/bin/pip install -e converter[test]
-.venv/bin/pytest converter
+pip install -e "./converter[test]"
+pytest converter
 ```


### PR DESCRIPTION
Follow-up to #19, which merged before its last two commits were included.

Brings the remaining two commits to `main`:

- **Rewrite the converter README as a how-to guide** — reframes `converter/README.md` around *using* the tool (install → run → options → what gets generated) instead of the internal component/status inventory. Example YAML and the column→LinkML mapping were checked against real converter output.
- **Use plain code fences for command examples** — drops the `sh` language tag that mis-coloured the command examples (highlighting the hyphens in `radx-dd-to-linkml`/`-o`/`--name` as operators); keeps yaml/csv/python highlighting where it helps.

No code changes — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)