### PR TITLE
Add reverse converter (LinkML → data dictionary CSV) + round-trip

### DIFF
--- a/converter/README.md
+++ b/converter/README.md
@@ -145,6 +145,24 @@ multi-line descriptions use block (`|`) style, and each enum, section, and data
 element carries a short comment block noting its position and (for enums and
 sections) which data elements reference it.
 
+## Reconstructing the dictionary (round-trip)
+
+The reverse tool `linkml-to-radx-dd` rebuilds a data dictionary CSV from a
+generated schema:
+
+```
+linkml-to-radx-dd my_schema.yaml -o my_dictionary.csv
+```
+
+The round-trip (CSV → LinkML → CSV) is **semantic, not byte-exact**: the forward
+conversion normalises some things for readability — it strips trailing
+whitespace and blank lines from descriptions, re-joins `Terms` with single
+spaces, treats a blank `Cardinality` as the default `single`, and re-serialises
+the `Enumeration` cell in a canonical `"value"=[label](iri)` form. The
+reconstructed dictionary carries the same information (verified field-by-field
+on the worked examples) but a cell may not match the original character for
+character.
+
 ## Worked examples
 
 The [`examples/`](examples/) folder contains real data dictionaries and the

--- a/converter/pyproject.toml
+++ b/converter/pyproject.toml
@@ -19,6 +19,7 @@ test = ["pytest>=7"]
 
 [project.scripts]
 radx-dd-to-linkml = "radx_dd_converter.cli:main"
+linkml-to-radx-dd = "radx_dd_converter.reverse:main"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/converter/radx_dd_converter/__init__.py
+++ b/converter/radx_dd_converter/__init__.py
@@ -15,6 +15,7 @@ from .datatypes import (
     resolve_datatype,
 )
 from .emit import EmitOptions, Emitter, emit_schema
+from .reverse import schema_to_csv, schema_to_rows
 from .missing_values import (
     STANDARD_ENUM_NAME,
     STANDARD_MISSING_VALUE_CODES,
@@ -38,6 +39,8 @@ __all__ = [
     "EmitOptions",
     "Emitter",
     "emit_schema",
+    "schema_to_csv",
+    "schema_to_rows",
     "STANDARD_ENUM_NAME",
     "STANDARD_MISSING_VALUE_CODES",
     "STANDARD_MISSING_VALUE_CODES_TEXT",

--- a/converter/radx_dd_converter/reverse.py
+++ b/converter/radx_dd_converter/reverse.py
@@ -1,0 +1,203 @@
+"""Reconstruct a RADx data dictionary CSV from a generated LinkML schema.
+
+This is the inverse of :mod:`emit`. It reads a schema produced by this converter
+and rebuilds the data dictionary, one row per slot of the root class, inverting
+the column -> LinkML mapping.
+
+The round-trip is *semantic*, not byte-exact: the forward conversion normalises
+some text (it strips trailing whitespace from descriptions and re-joins ``Terms``
+with single spaces) and re-serialises the ``Enumeration`` cell grammar, so a
+reconstructed cell may be equivalent to the original without being identical.
+See ``linkml/CONVERTER_PLAN.md``.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from typing import TextIO
+
+import jsonasobj2
+import yaml
+
+from .missing_values import STANDARD_ENUM_NAME
+from .reader import KNOWN_COLUMNS
+
+
+def _get(obj, attr, default=None):
+    """Attribute access that works on both LinkML JsonObj and plain dicts."""
+    if isinstance(obj, dict):
+        return obj.get(attr, default)
+    return getattr(obj, attr, default) or default
+
+
+def _items(mapping):
+    """Iterate (key, value) over a JsonObj-or-dict mapping."""
+    if mapping is None:
+        return []
+    return list(jsonasobj2.items(mapping))
+
+
+def _annotation(slot, key: str) -> str:
+    """Return the string value of a slot annotation, or ""."""
+    annotations = _get(slot, "annotations", {})
+    for name, ann in _items(annotations):
+        if name == key:
+            # An annotation serialises either as a bare value or {value: ...}.
+            return str(_get(ann, "value", ann) if not isinstance(ann, str) else ann)
+    return ""
+
+
+def _enum_to_cell(enum) -> str:
+    """Re-serialise an enum's permissible values as an Enumeration cell.
+
+    Produces ``"value"=[label](iri) | ...`` — the grammar the forward parser
+    consumes. Uses single spaces around ``|`` and ``=`` (canonical form; the
+    original cell's incidental spacing is not recoverable).
+    """
+    parts = []
+    for value, pv in _items(_get(enum, "permissible_values", {})):
+        label = _get(pv, "title", "") or _get(pv, "description", "") or ""
+        meaning = _get(pv, "meaning", "")
+        item = f'"{value}"=[{label}]'
+        if meaning:
+            item += f"({meaning})"
+        parts.append(item)
+    return " | ".join(parts)
+
+
+def _terms_to_cell(slot) -> str:
+    """Space-join the slot's related_mappings back into a Terms cell."""
+    return " ".join(str(t) for t in _get(slot, "related_mappings", []))
+
+
+def schema_to_rows(schema: dict) -> list[dict]:
+    """Reconstruct data dictionary rows (dicts keyed by column) from a schema."""
+    classes = _items(_get(schema, "classes", {}))
+    if not classes:
+        return []
+    # The datafile class is the tree_root (fall back to the first class).
+    root = next((c for _, c in classes if _get(c, "tree_root")), classes[0][1])
+    enums = dict(_items(_get(schema, "enums", {})))
+    subsets = dict(_items(_get(schema, "subsets", {})))
+
+    rows: list[dict] = []
+    for slot_name, slot in _items(_get(root, "attributes", {})):
+        row = dict.fromkeys(KNOWN_COLUMNS, "")
+
+        # Id: prefer the original (pre-sanitisation) id if it was recorded.
+        row["Id"] = _annotation(slot, "original_id") or slot_name
+        row["Label"] = _get(slot, "title", "")
+        row["Description"] = _get(slot, "description", "")
+        row["Notes"] = " ".join(str(c) for c in _get(slot, "comments", []))
+        row["SeeAlso"] = " ".join(str(s) for s in _get(slot, "see_also", []))
+        row["Aliases"] = "|".join(str(a) for a in _get(slot, "aliases", []))
+        row["Examples"] = "|".join(
+            str(_get(ex, "value", ex)) for ex in _get(slot, "examples", [])
+        )
+        # `single` is the spec default, so a non-multivalued slot could have had
+        # either "single" or a blank cell originally; we emit the explicit
+        # "single" (never wrong, and the common form).
+        row["Cardinality"] = "multiple" if _get(slot, "multivalued") else "single"
+        row["Pattern"] = _get(slot, "pattern", "")
+        row["Terms"] = _terms_to_cell(slot)
+
+        # Provenance: emitted as source: (URL/CURIE) or an annotation otherwise.
+        row["Provenance"] = _get(slot, "source", "") or _annotation(slot, "provenance")
+
+        # Unit: the raw cell was preserved as an annotation.
+        row["Unit"] = _annotation(slot, "unit_raw")
+
+        # Section: the slot's subset, whose title is the original section name.
+        in_subset = _get(slot, "in_subset", [])
+        if in_subset:
+            subset_name = str(in_subset[0])
+            subset = subsets.get(subset_name)
+            # The subset's title is the original Section name.
+            row["Section"] = _get(subset, "title", subset_name) if subset else subset_name
+
+        # Datatype / Enumeration / MissingValueCodes come from the range.
+        _apply_range(row, slot, enums)
+
+        rows.append(row)
+    return rows
+
+
+def _apply_range(row: dict, slot, enums: dict) -> None:
+    """Invert the Datatype/Enumeration/MissingValueCodes mapping for one slot."""
+    any_of = _get(slot, "any_of", [])
+    if any_of:
+        # Enumerated slot: any_of = [field enum, StandardMissingValueCodes,
+        # (field-specific codes)]. Datatype was kept in value_datatype.
+        row["Datatype"] = _annotation(slot, "value_datatype") or "string"
+        ranges = [str(_get(branch, "range", "")) for branch in any_of]
+        field_enum = next(
+            (r for r in ranges if r and r != STANDARD_ENUM_NAME), None
+        )
+        if field_enum and field_enum in enums:
+            row["Enumeration"] = _enum_to_cell(enums[field_enum])
+        # A third branch (besides the field enum and the standard codes) is the
+        # field's own MissingValueCodes.
+        extra = [
+            r for r in ranges
+            if r and r != STANDARD_ENUM_NAME and r != field_enum and r in enums
+        ]
+        if extra:
+            row["MissingValueCodes"] = _enum_to_cell(enums[extra[0]])
+    else:
+        row["Datatype"] = _get(slot, "range", "") or "string"
+
+
+def write_csv(rows: list[dict], handle: TextIO) -> None:
+    """Write reconstructed rows as a data dictionary CSV (canonical column order)."""
+    writer = csv.DictWriter(handle, fieldnames=list(KNOWN_COLUMNS))
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)
+
+
+def schema_to_csv(schema_yaml: str) -> str:
+    """Convert a generated LinkML schema (YAML text) to a data dictionary CSV."""
+    schema = yaml.safe_load(schema_yaml)
+    rows = schema_to_rows(schema)
+    buffer = io.StringIO()
+    write_csv(rows, buffer)
+    return buffer.getvalue()
+
+
+def main(argv=None) -> int:
+    """CLI: reconstruct a data dictionary CSV from a generated LinkML schema.
+
+    Usage: ``linkml-to-radx-dd SCHEMA.yaml -o DICTIONARY.csv``. The round-trip is
+    semantic, not byte-exact (see the module docstring).
+    """
+    import argparse
+    import sys
+    from pathlib import Path
+
+    parser = argparse.ArgumentParser(
+        prog="linkml-to-radx-dd",
+        description="Reconstruct a RADx data dictionary CSV from a LinkML schema.",
+    )
+    parser.add_argument("input", type=Path, help="Path to the LinkML schema YAML.")
+    parser.add_argument(
+        "-o", "--output", type=Path, default=None,
+        help="Output CSV file (default: stdout).",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.input.exists():
+        print(f"error: input file not found: {args.input}", file=sys.stderr)
+        return 2
+
+    csv_text = schema_to_csv(args.input.read_text(encoding="utf-8"))
+    if args.output is None:
+        sys.stdout.write(csv_text)
+    else:
+        args.output.write_text(csv_text, encoding="utf-8")
+        print(f"Wrote {args.output}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/converter/tests/test_reverse.py
+++ b/converter/tests/test_reverse.py
@@ -1,0 +1,88 @@
+"""Round-trip tests: CSV -> LinkML -> CSV should be semantically equivalent."""
+
+import io
+
+from radx_dd_converter import (
+    EmitOptions,
+    emit_schema,
+    read_data_dictionary,
+    schema_to_csv,
+)
+from radx_dd_converter.grammar import parse_enumeration, parse_terms
+
+# A small dictionary exercising the tricky columns: an enumeration (with an
+# ontology meaning), a multivalued field, a datatype, terms, unit, section,
+# aliases, examples, and a field-specific missing-value code.
+SAMPLE = (
+    "Id,Label,Description,Section,Cardinality,Terms,Datatype,Pattern,Unit,"
+    "Enumeration,MissingValueCodes,Notes,Provenance,SeeAlso,Aliases,Examples\n"
+    "part_id,Participant,The participant,IDs,single,,string,^[NP]\\d+$,,,,note1,,,"
+    "pid|subject_id,N001|N002\n"
+    'sample,Sample Type,The sample,Lab,single,UBERON:0001836,integer,,,'
+    '"""0""=[Saliva](UBERON:0001836) | ""1""=[Blood]",'
+    '"""-1""=[Refused]",,,,,\n'
+    "height,Height,The height,Lab,single,,decimal,,mm,,,,,,,\n"
+)
+
+
+def _norm(s):
+    return " ".join((s or "").split())
+
+
+def _roundtrip(csv_text):
+    orig = read_data_dictionary(io.StringIO(csv_text))
+    schema = emit_schema(orig, EmitOptions(schema_name="s", class_name="Record"))
+    rebuilt = read_data_dictionary(io.StringIO(schema_to_csv(schema)))
+    return orig, rebuilt
+
+
+def test_roundtrip_preserves_all_ids():
+    orig, rebuilt = _roundtrip(SAMPLE)
+    assert [r.id for r in orig] == [r.id for r in rebuilt]
+
+
+def test_roundtrip_semantic_equivalence():
+    orig, rebuilt = _roundtrip(SAMPLE)
+    o = {r.id: r for r in orig}
+    b = {r.id: r for r in rebuilt}
+    columns = [
+        "Id", "Label", "Description", "Section", "Pattern", "Unit", "Datatype",
+        "Notes", "Provenance", "SeeAlso", "Aliases", "Examples",
+    ]
+    for rid in o:
+        for col in columns:
+            assert _norm(o[rid].get(col)) == _norm(b[rid].get(col)), (rid, col)
+        # Cardinality: blank and "single" are equivalent (single is the default).
+        assert (_norm(o[rid].get("Cardinality")) or "single") == (
+            _norm(b[rid].get("Cardinality")) or "single"
+        )
+        # Enumeration / Terms compared as parsed structures, not raw text.
+        assert parse_enumeration(o[rid].get("Enumeration")) == parse_enumeration(
+            b[rid].get("Enumeration")
+        )
+        assert parse_enumeration(o[rid].get("MissingValueCodes")) == parse_enumeration(
+            b[rid].get("MissingValueCodes")
+        )
+        assert parse_terms(o[rid].get("Terms")) == parse_terms(b[rid].get("Terms"))
+
+
+def test_enumeration_cell_reconstructed_with_meaning():
+    _, rebuilt = _roundtrip(SAMPLE)
+    sample = {r.id: r for r in rebuilt}["sample"]
+    items = parse_enumeration(sample.get("Enumeration"))
+    assert [(i.value, i.label) for i in items] == [("0", "Saliva"), ("1", "Blood")]
+    assert items[0].iri == "UBERON:0001836"  # ontology meaning survived
+
+
+def test_datatype_under_enumeration_preserved():
+    _, rebuilt = _roundtrip(SAMPLE)
+    # `sample` has an enumeration but its Datatype was integer; it must come back.
+    assert {r.id: r for r in rebuilt}["sample"].get("Datatype") == "integer"
+
+
+def test_field_missing_value_codes_preserved():
+    _, rebuilt = _roundtrip(SAMPLE)
+    codes = parse_enumeration(
+        {r.id: r for r in rebuilt}["sample"].get("MissingValueCodes")
+    )
+    assert [(c.value, c.label) for c in codes] == [("-1", "Refused")]


### PR DESCRIPTION
Answers "can this round-trip?" — adds a reverse converter so a data dictionary can be reconstructed from a generated schema, and verifies CSV → LinkML → CSV is semantically equivalent.

## New
- **`radx_dd_converter/reverse.py`** + a **`linkml-to-radx-dd`** console script. It inverts the emitter's mapping: enum permissible-values → the `Enumeration` cell grammar; `value_datatype`/`unit_raw`/`original_id` annotations → their columns; `in_subset` → `Section`; the `any_of` union → `Datatype` + field-specific `MissingValueCodes`; `related_mappings` → `Terms`; etc.

```
radx-dd-to-linkml my_dictionary.csv -o my_schema.yaml
linkml-to-radx-dd my_schema.yaml   -o my_dictionary.csv
```

## Round-trip result
Semantic, **not byte-exact** — by design. The forward pass normalises for readability: strips description whitespace/blank lines, re-joins `Terms` with single spaces, treats blank `Cardinality` as the default `single`, and re-serialises the `Enumeration` cell canonically. So a reconstructed cell carries the same information but may not match the original character-for-character.

Verified field-by-field on both worked examples — **gcb (133 rows) and rad (888 rows), zero mismatches across all 16 columns** (enumerations and `Terms` compared as parsed structures, whitespace normalised).

## Tests
5 new round-trip tests (semantic equivalence, enum-cell reconstruction incl. ontology meaning, datatype-under-enumeration, field-specific missing-value codes). 136 total; ruff clean; forward output byte-identical (emitter untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)