### PR TITLE
Round-trip test on example dictionaries + README for reverse conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,37 +20,29 @@ of it.
 | Path | What it is |
 | --- | --- |
 | [`radx-data-dictionary-specification.md`](radx-data-dictionary-specification.md) | The authoritative specification. |
-| [`linkml/`](linkml/) | [LinkML](https://linkml.io) renderings of the specification (see below). |
-| [`converter/`](converter/) | `radx-dd-to-linkml` — a Python tool that converts a data dictionary CSV into a LinkML schema. |
-
-## LinkML representation
-
-The [`linkml/`](linkml/) folder holds two LinkML renderings of the
-specification, plus the converter's design notes:
-
-- [`linkml/data-dictionary-csv.yaml`](linkml/data-dictionary-csv.yaml) — a
-  **CSV-faithful** schema: one row per data element, every column a single
-  string cell. Rich values (enumerations, ontology terms) stay encoded in-cell
-  using the grammars defined in the specification.
-- [`linkml/data-dictionary.yaml`](linkml/data-dictionary.yaml) — the **parsed
-  object model**: the same information once the in-cell grammars have been
-  decomposed into structured objects.
-- [`linkml/CONVERTER_PLAN.md`](linkml/CONVERTER_PLAN.md) — the design record for
-  the converter.
+| [`converter/`](converter/) | A Python tool that converts between a data dictionary CSV and a LinkML schema, in both directions. |
+| [`linkml/`](linkml/) | Hand-written [LinkML](https://linkml.io) renderings of the specification. |
 
 ## Converter
 
-[`converter/`](converter/) contains `radx-dd-to-linkml`, which reads a RADx data
-dictionary CSV and emits a LinkML schema describing the *target datafile* (one
-slot per data element):
+[`converter/`](converter/) is a Python tool that translates **both directions**
+between a data dictionary and a [LinkML](https://linkml.io) schema:
 
 ```sh
 pip install ./converter
+
+# Data dictionary CSV -> LinkML schema
 radx-dd-to-linkml my_dictionary.csv -o my_schema.yaml
+
+# LinkML schema -> data dictionary CSV
+linkml-to-radx-dd my_schema.yaml -o my_dictionary.csv
 ```
 
-See the [converter README](converter/README.md) for the full set of options
-(ontology term-name lookup, enum-value annotations, and more).
+The generated schema describes the *target datafile* — one slot per data
+element — so datafiles can be validated and documented with standard LinkML
+tooling. The round-trip is *semantic* (the same information is preserved), not
+byte-exact. See the [converter README](converter/README.md) for the full set of
+options and the mapping details.
 
 ### Worked examples
 
@@ -61,6 +53,14 @@ them:
 | --- | --- |
 | [`gcb.dd.csv`](converter/examples/gcb.dd.csv) | [`gcb.yaml`](converter/examples/gcb.yaml) |
 | [`rad.dd.csv`](converter/examples/rad.dd.csv) | [`rad.yaml`](converter/examples/rad.yaml) |
+
+## Hand-written LinkML schemas
+
+Alongside the converter, [`linkml/`](linkml/) holds two hand-written LinkML
+renderings of the specification itself — one **CSV-faithful** (every column a
+single string cell) and one **parsed object model** (in-cell grammars decomposed
+into structured objects) — plus [`CONVERTER_PLAN.md`](linkml/CONVERTER_PLAN.md),
+the converter's design record.
 
 ## License
 

--- a/converter/tests/test_reverse.py
+++ b/converter/tests/test_reverse.py
@@ -1,6 +1,9 @@
 """Round-trip tests: CSV -> LinkML -> CSV should be semantically equivalent."""
 
 import io
+from pathlib import Path
+
+import pytest
 
 from radx_dd_converter import (
     EmitOptions,
@@ -9,6 +12,8 @@ from radx_dd_converter import (
     schema_to_csv,
 )
 from radx_dd_converter.grammar import parse_enumeration, parse_terms
+
+EXAMPLES = Path(__file__).resolve().parents[1] / "examples"
 
 # A small dictionary exercising the tricky columns: an enumeration (with an
 # ontology meaning), a multivalued field, a datatype, terms, unit, section,
@@ -86,3 +91,56 @@ def test_field_missing_value_codes_preserved():
         {r.id: r for r in rebuilt}["sample"].get("MissingValueCodes")
     )
     assert [(c.value, c.label) for c in codes] == [("-1", "Refused")]
+
+
+# --- Round-trip on the committed real-world example dictionaries ------------
+
+# gcb is spec-clean; rad has duplicate Ids (kept-first via allow_duplicates).
+_EXAMPLE_DICTS = [
+    pytest.param("gcb.dd.csv", False, id="gcb"),
+    pytest.param("rad.dd.csv", True, id="rad"),
+]
+
+
+def _column_equivalent(column: str, original: str, rebuilt: str) -> bool:
+    """Compare a reconstructed column to the original, allowing the forward
+    conversion's documented normalisations (whitespace, Terms spacing, blank
+    ==single Cardinality, canonical Enumeration serialisation)."""
+    if column in ("Enumeration", "MissingValueCodes"):
+        return parse_enumeration(original) == parse_enumeration(rebuilt)
+    if column == "Terms":
+        return parse_terms(original) == parse_terms(rebuilt)
+    if column == "Cardinality":
+        return (_norm(original) or "single") == (_norm(rebuilt) or "single")
+    return _norm(original) == _norm(rebuilt)
+
+
+@pytest.mark.parametrize("filename, allow_dup", _EXAMPLE_DICTS)
+def test_example_dictionary_roundtrips(filename, allow_dup):
+    """Each committed example dictionary must survive CSV -> LinkML -> CSV with
+    every column semantically equivalent for every data element."""
+    path = EXAMPLES / filename
+    if not path.exists():
+        pytest.skip(f"{filename} not available")
+
+    original = read_data_dictionary(path, allow_duplicates=allow_dup)
+    schema = emit_schema(original, EmitOptions(schema_name="ex", class_name="Record"))
+    rebuilt = read_data_dictionary(
+        io.StringIO(schema_to_csv(schema)), allow_duplicates=allow_dup
+    )
+
+    orig_by_id = {r.id: r for r in original}
+    rebuilt_by_id = {r.id: r for r in rebuilt}
+    assert set(orig_by_id) == set(rebuilt_by_id)
+
+    from radx_dd_converter.reader import KNOWN_COLUMNS
+
+    mismatches = []
+    for row_id, orig_row in orig_by_id.items():
+        rebuilt_row = rebuilt_by_id[row_id]
+        for column in KNOWN_COLUMNS:
+            if not _column_equivalent(
+                column, orig_row.get(column), rebuilt_row.get(column)
+            ):
+                mismatches.append(f"{row_id}.{column}")
+    assert not mismatches, f"{len(mismatches)} column mismatches: {mismatches[:10]}"


### PR DESCRIPTION
Locks the CSV → LinkML → CSV round-trip guarantee on real data, not just the small synthetic fixture.

A parametrised test runs each committed example — `gcb.dd.csv` (133 data elements) and `rad.dd.csv` (888, with duplicate Ids handled via `allow_duplicates`) — through the forward and reverse converters and asserts that **every one of the 16 columns is semantically equivalent for every data element**.

Comparison allows the forward pass's documented normalisations: enumerations and `Terms` are compared as parsed structures (not raw text), whitespace is collapsed, and a blank `Cardinality` is treated as the default `single`.

Offline (no `--annotate-terms`, so no network). 138 tests total; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)