### PR TITLE
Document one-command install from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,15 @@ of it.
 [`converter/`](converter/) is a Python tool that translates **both directions**
 between a data dictionary and a [LinkML](https://linkml.io) schema:
 
-```sh
-pip install ./converter
+Install it straight from this repository (no clone needed):
 
+```sh
+pip install "git+https://github.com/bmir-radx/radx-data-dictionary-specification.git#subdirectory=converter"
+```
+
+Then convert in either direction:
+
+```sh
 # Data dictionary CSV -> LinkML schema
 radx-dd-to-linkml my_dictionary.csv -o my_schema.yaml
 

--- a/converter/README.md
+++ b/converter/README.md
@@ -8,14 +8,22 @@ or transform with the wider LinkML tool ecosystem.
 
 ## Install
 
-From the repository root:
+Install directly from the repository — no clone required:
 
 ```
-pip install ./converter
+pip install "git+https://github.com/bmir-radx/radx-data-dictionary-specification.git#subdirectory=converter"
 ```
 
-This installs the `radx-dd-to-linkml` command and its dependencies
-(`linkml`, `lark`).
+For a CLI tool, [`pipx`](https://pipx.pypa.io) installs it into its own isolated
+environment and puts the commands on your `PATH`:
+
+```
+pipx install "git+https://github.com/bmir-radx/radx-data-dictionary-specification.git#subdirectory=converter"
+```
+
+Either way this installs the `radx-dd-to-linkml` and `linkml-to-radx-dd`
+commands and their dependencies (`linkml`, `lark`). If you have cloned the
+repository, `pip install ./converter` from the repo root works too.
 
 ## Use it
 


### PR DESCRIPTION
Makes the converter easier to install: instead of "clone the repo, then `pip install ./converter`", you can now install it with a single command straight from GitHub — no clone.

```sh
pip install "git+https://github.com/bmir-radx/radx-data-dictionary-specification.git#subdirectory=converter"
```

- Updated both the root README and the converter README.
- Added a `pipx` variant (isolated CLI install) in the converter README.
- The clone-based `pip install ./converter` is still noted as an alternative.

Verified the command installs both console scripts (`radx-dd-to-linkml`, `linkml-to-radx-dd`) and runs end-to-end in a fresh virtualenv against the real repository.

Docs only — no code changes. (PyPI publishing was considered but deferred; it needs an account, name reservation, and an ongoing maintainer.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)