### PR TITLE
Note pipx ensurepath in the converter README

### DIFF
--- a/converter/README.md
+++ b/converter/README.md
@@ -21,6 +21,10 @@ environment and puts the commands on your `PATH`:
 pipx install "git+https://github.com/bmir-radx/radx-data-dictionary-specification.git#subdirectory=converter"
 ```
 
+On first use of pipx, its bin directory may not be on your `PATH` (pipx warns
+if so). Run `pipx ensurepath` once — then open a new terminal — to add it, after
+which the commands are available everywhere.
+
 Either way this installs the `radx-dd-to-linkml` and `linkml-to-radx-dd`
 commands and their dependencies (`linkml`, `lark`). If you have cloned the
 repository, `pip install ./converter` from the repo root works too.


### PR DESCRIPTION
Small docs addition: pipx warns on first install when its bin directory isn't on `PATH` (as seen when testing the install command). Add a note telling users to run `pipx ensurepath` once — and open a new terminal — so the installed `radx-dd-to-linkml` / `linkml-to-radx-dd` commands are found.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)