### PR TITLE
Add data dictionary printer (dd-print)

### DIFF
--- a/printer/PRINTER_PLAN.md
+++ b/printer/PRINTER_PLAN.md
@@ -1,0 +1,108 @@
+# Data Dictionary Printer (Python) — Design
+
+> **Status:** Planning. A Python port of the Java printer at
+> `radx-data-dictionary-printer`, scoped to the core printing pipeline. It lives
+> here as a sibling to [`../converter/`](../converter/) so it can reuse the
+> converter's parsing code directly.
+>
+> **De-branded / generic:** the printer itself carries no "RADx" naming or
+> RADx-specific concepts (no program badges, tiers, or harmonization). It is a
+> neutral *data dictionary* printer. Package `dd_printer`, command `dd-print`.
+> (The input still comes from the RADx-aware converter; the printer stays
+> vocabulary-neutral.)
+
+## Goal
+
+Render a RADx data dictionary into human-readable output — primarily a
+**self-contained HTML page** (and JSON), grouped by section, with each data
+element shown as a card: its id, label, facets (datatype, cardinality, unit,
+pattern), description (Markdown → HTML), and enumeration choices.
+
+## Scope
+
+**In scope** — the core printing pipeline from the Java app:
+- Group records by `Section` (preserving order), numbered 1..N across the whole
+  dictionary.
+- Render `Description` (and `Notes`) from Markdown to HTML.
+- Enrichments applied to the description markdown before rendering:
+  - backtick-wrapped record ids (`` `nih_race` ``) → in-page cross-reference links;
+  - enumeration choice values (`` `0` ``) → styled badges, flagged when they are
+    missing-value codes.
+- HTML output (Bootstrap-styled, print-friendly, per-record cards) and JSON.
+
+**Out of scope** (was RADx Tier 1-specific; becomes a separate data-harmonization
+effort later): the entire mappings subsystem — program mappings, enumeration
+mappings, `Augmented*`/`Mapped*` model classes, `TermOracle` + reference
+ontologies, `RadxProgram` badges, harmonized-id spans, and the harmonization
+parts of `DescriptionGenerator`. **Do not port these.**
+
+## Input (decided direction, confirm in first session)
+
+Read the **LinkML data dictionary schema** produced by `../converter/`
+(`radx-dd-to-linkml`), reusing the converter's reader/reverse code, rather than
+re-implementing a CSV parser. A data dictionary CSV can be printed by running it
+through the converter first (or we accept CSV directly via the converter's
+`read_data_dictionary`). This is the main reason the printer lives in this repo.
+
+## Output formats (reproduce the Java behaviour)
+
+- **HTML**: one page. `<head>` pulls in Bootstrap 4.4.1 (CDN) + an inline
+  `<style>` block (copy the rules from `template.html`: `.record`, `.record__id`,
+  `.record__facet`, `.badge`, `.choice__value`, print `@media` rules, etc.).
+  Body = a section-by-section list; each record is a card showing number, id
+  (anchored `id=` for cross-refs), label, facet badges, rendered description,
+  and the enumeration table. Java uses Thymeleaf; **Python uses Jinja2**.
+- **JSON**: the sectioned/record model serialised (pretty-printed). Define the
+  Python model (dataclasses) to mirror the useful fields of
+  `AugmentedDataDictionaryRecord` minus the mapping fields.
+
+## Description generation (optional, non-mapping part)
+
+`DescriptionGenerator` can synthesise a sentence when a description is absent:
+"The `<id>` data element records responses to the prompt \"<label>\". The values
+for this data element are <type>s [that come from a list of N permissible
+<type> values]." Keep this non-mapping core; drop the harmonized-prompt parts.
+
+## Architecture (proposed)
+
+```
+printer/
+  dd_printer/
+    model.py       # dataclasses: Section, Record, Choice (no mapping fields)
+    load.py        # LinkML schema (or CSV via converter) -> [Section] of Records
+    markdown.py    # description enrichment (id links, choice badges) + md->html
+    render_html.py # Jinja2 template -> self-contained HTML
+    render_json.py # model -> JSON
+    cli.py         # dd-print IN -o OUT [--format html|json]
+    templates/dictionary.html.j2
+    static/dictionary.css   # extracted from template.html
+  tests/
+```
+Depends on: the local `radx_dd_converter` package, `markdown-it-py`, and Jinja2.
+
+## Resolved decisions
+
+1. **Input surface (decided)**: accept **both** a data dictionary CSV (via the
+   converter's `read_data_dictionary`) and a generated LinkML schema. `load.py`
+   sniffs the input (`.csv` vs `.yaml`) and normalises to the printer model.
+2. **HTML self-containment (decided)**: **fully self-contained** — inline all
+   CSS in the page (no Bootstrap CDN link); the output is one portable file that
+   renders offline. The bespoke `.record`/`.badge`/etc. rules from
+   `template.html` are inlined; Bootstrap-specific utility classes are replaced
+   with equivalent local styles rather than pulling the CDN.
+3. **Markdown library (decided)**: `markdown-it-py` (CommonMark-compliant,
+   closest to the Java commonmark; linkify plugin for the autolink behaviour).
+
+## Open questions (still to decide)
+
+- **Term names in output**: reuse the converter's `terms_lookup` to show
+  human-readable labels for ontology terms? (Optional, network.) Defer.
+- **Command name (decided)**: `dd-print` (kebab-case, neutral — no "radx").
+
+## Reference (Java source to reproduce)
+
+`radx-data-dictionary-printer/src/main/java/.../`: `Renderer` (enrichment +
+md→html), `SectionedDataDictionary` / `DataDictionarySection` (grouping +
+numbering), `DataDictionaryHtmlRenderer` / `DataDictionaryJsonRenderer`,
+`DescriptionGenerator` (non-mapping part), and `src/main/resources/template.html`
+(the HTML/CSS to reproduce).

--- a/printer/README.md
+++ b/printer/README.md
@@ -1,0 +1,67 @@
+# Data Dictionary Printer
+
+`dd-print` renders a data dictionary into a human-readable, self-contained
+**HTML page** (or JSON). The dictionary is grouped by section, and each data
+element is shown as a card: its id, label, facets (datatype, cardinality, unit,
+pattern), ontology terms, a Markdown-rendered description, and its enumeration
+of permissible values.
+
+The input can be a data dictionary **CSV** or a **LinkML schema** produced by the
+sibling [converter](../converter/) — the format is detected automatically.
+
+## Install
+
+For a command-line tool, [`pipx`](https://pipx.pypa.io) is the recommended way to
+install it — it puts `dd-print` on your `PATH` in its own isolated environment:
+
+```
+pipx install "git+https://github.com/bmir-radx/radx-data-dictionary-specification.git#subdirectory=printer"
+```
+
+On first use of pipx, its bin directory may not be on your `PATH` (pipx warns if
+so). Run `pipx ensurepath` once — then open a new terminal — to add it.
+
+The printer depends on the converter package (for reading dictionaries); the
+command above pulls it in automatically. To install into an existing environment
+instead of an isolated one, use `pip` in place of `pipx`.
+
+## Use it
+
+```
+# Render to a self-contained HTML page
+dd-print my_dictionary.csv -o my_dictionary.html
+
+# ...from a generated LinkML schema instead of a CSV (auto-detected)
+dd-print my_schema.yaml -o my_dictionary.html
+
+# Render to JSON (format inferred from the .json extension)
+dd-print my_dictionary.csv -o my_dictionary.json
+
+# Write to stdout (HTML by default) so you can pipe it
+dd-print my_dictionary.csv | less
+```
+
+Options:
+
+| Option | Effect |
+| --- | --- |
+| `-o`, `--output` | Output file (default: stdout). |
+| `-f`, `--format` | `html` or `json` (default: inferred from the `-o` extension, else `html`). |
+| `--title` | Document title (default: the input filename). |
+
+## What it produces
+
+- **HTML** — one self-contained file (all CSS inlined, no external assets), so it
+  opens offline and prints cleanly. Sections become headed groups; each data
+  element is a card. Descriptions are rendered from Markdown, with two
+  conveniences: a backtick-quoted record id (`` `age` ``) becomes an in-page
+  link to that record, and a backtick-quoted enumeration value (`` `0` ``)
+  becomes a value badge (missing-value codes are styled distinctly).
+- **JSON** — the sectioned model (sections → records → choices), pretty-printed.
+
+## Development
+
+```
+pip install -e "./printer[test]"
+pytest printer
+```

--- a/printer/dd_printer/__init__.py
+++ b/printer/dd_printer/__init__.py
@@ -1,0 +1,11 @@
+"""Render a data dictionary to human-readable HTML or JSON.
+
+A vocabulary-neutral printer: it groups a dictionary's data elements by section
+and renders each as a card (id, label, facets, description, enumeration). See
+``PRINTER_PLAN.md``. Input is loaded via the sibling ``radx_dd_converter``
+package (from a data dictionary CSV or a generated LinkML schema).
+"""
+
+from .model import Choice, Dictionary, Record, Section
+
+__all__ = ["Choice", "Record", "Section", "Dictionary"]

--- a/printer/dd_printer/cli.py
+++ b/printer/dd_printer/cli.py
@@ -1,0 +1,68 @@
+"""Command-line interface: render a data dictionary to HTML or JSON.
+
+Usage: ``dd-print INPUT [-o OUTPUT] [--format html|json]``. INPUT may be a data
+dictionary CSV or a generated LinkML schema (auto-detected).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from .load import load_dictionary
+from .render_html import render_html
+from .render_json import render_json
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="dd-print",
+        description="Render a data dictionary (CSV or LinkML schema) to HTML or JSON.",
+    )
+    parser.add_argument(
+        "input", type=Path, help="Data dictionary CSV or LinkML schema."
+    )
+    parser.add_argument(
+        "-o", "--output", type=Path, default=None,
+        help="Output file (default: stdout).",
+    )
+    parser.add_argument(
+        "-f", "--format", choices=("html", "json"), default=None,
+        help="Output format (default: inferred from -o extension, else html).",
+    )
+    parser.add_argument("--title", default=None, help="Document title (default: filename).")
+    return parser
+
+
+def _resolve_format(args: argparse.Namespace) -> str:
+    if args.format:
+        return args.format
+    if args.output and args.output.suffix.lower() == ".json":
+        return "json"
+    return "html"
+
+
+def main(argv=None) -> int:
+    args = _build_parser().parse_args(argv)
+    if not args.input.exists():
+        print(f"error: input file not found: {args.input}", file=sys.stderr)
+        return 2
+
+    dictionary = load_dictionary(args.input, title=args.title)
+    output_format = _resolve_format(args)
+    rendered = render_json(dictionary) if output_format == "json" else render_html(dictionary)
+
+    if args.output is None:
+        sys.stdout.write(rendered)
+    else:
+        args.output.write_text(rendered, encoding="utf-8")
+        print(
+            f"Wrote {len(dictionary.records)} data elements to {args.output}",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/printer/dd_printer/load.py
+++ b/printer/dd_printer/load.py
@@ -1,0 +1,104 @@
+"""Load a data dictionary into the printer model.
+
+Input may be a data dictionary **CSV** or a generated **LinkML schema** — both
+are read via the sibling ``radx_dd_converter`` package and normalised to the same
+list of column dicts, then grouped into the printer's :class:`Dictionary` model.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import yaml
+
+from radx_dd_converter import read_data_dictionary, schema_to_rows
+from radx_dd_converter.grammar import parse_enumeration, parse_missing_value_codes, parse_terms
+
+from .model import Choice, Dictionary, Record, Section
+
+
+def _rows_from_csv(source) -> list[dict]:
+    """Read a data dictionary CSV into a list of column dicts."""
+    rows = read_data_dictionary(source, allow_duplicates=True)
+    return [dict(r.cells) for r in rows]
+
+
+def _rows_from_schema(text: str) -> list[dict]:
+    """Read a generated LinkML schema (YAML text) into a list of column dicts."""
+    return schema_to_rows(yaml.safe_load(text))
+
+
+def _looks_like_schema(text: str) -> bool:
+    """A generated LinkML schema has top-level ``classes:`` (a dictionary CSV
+    starts with an ``Id,...`` header)."""
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return False
+    return isinstance(data, dict) and "classes" in data
+
+
+def _build_dictionary(rows: list[dict], title: str) -> Dictionary:
+    """Group column dicts into sections of numbered records."""
+    sections: dict[str, Section] = {}  # section name -> Section (insertion order)
+    for position, cells in enumerate(rows, start=1):
+        record = _record_from_cells(cells, position)
+        section = sections.setdefault(record.section, Section(name=record.section))
+        section.records.append(record)
+    return Dictionary(title=title, sections=list(sections.values()))
+
+
+def _record_from_cells(cells: dict, number: int) -> Record:
+    def cell(name: str) -> str:
+        return (cells.get(name) or "").strip()
+
+    # Missing-value-code values, to flag them among the choices.
+    mvc_values = {c.value for c in parse_missing_value_codes(cells.get("MissingValueCodes") or "")}
+    choices = [
+        Choice(
+            value=item.value,
+            label=item.label or "",
+            meaning=item.iri,
+            is_missing_value_code=item.value in mvc_values,
+        )
+        for item in parse_enumeration(cells.get("Enumeration") or "")
+    ]
+    return Record(
+        number=number,
+        id=cell("Id"),
+        label=cell("Label"),
+        description=cells.get("Description") or "",
+        section=cell("Section"),
+        datatype=cell("Datatype"),
+        cardinality=cell("Cardinality"),
+        unit=cell("Unit"),
+        pattern=cells.get("Pattern") or "",
+        terms=parse_terms(cells.get("Terms") or ""),
+        choices=choices,
+        notes=cells.get("Notes") or "",
+        provenance=cell("Provenance"),
+        see_also=cell("SeeAlso"),
+    )
+
+
+def load_dictionary(source, title: str | None = None) -> Dictionary:
+    """Load a :class:`Dictionary` from a path (CSV or LinkML schema) or text stream.
+
+    The input kind is detected from the content (LinkML schemas have a top-level
+    ``classes:`` key); CSV is assumed otherwise. ``title`` defaults to the input
+    filename stem.
+    """
+    if isinstance(source, (str, Path)):
+        path = Path(source)
+        text = path.read_text(encoding="utf-8-sig")
+        resolved_title = title or path.stem
+    else:  # a text stream
+        text = source.read()
+        resolved_title = title or "Data Dictionary"
+
+    if _looks_like_schema(text):
+        rows = _rows_from_schema(text)
+    else:
+        rows = _rows_from_csv(io.StringIO(text))
+    return _build_dictionary(rows, resolved_title)

--- a/printer/dd_printer/markdown.py
+++ b/printer/dd_printer/markdown.py
@@ -1,0 +1,58 @@
+"""Render a record's Markdown description to HTML, with dictionary-aware enrichment.
+
+Before the Markdown is rendered, two enrichments rewrite backtick-quoted spans:
+
+* a backtick-quoted **record id** that exists in the dictionary
+  (`` `age` ``) becomes an in-page cross-reference link to that record;
+* a backtick-quoted **choice value** of the current record (`` `0` ``) becomes a
+  styled badge, marked when the value is a missing-value code.
+
+The enriched text is then rendered as CommonMark (with autolinking) into HTML.
+Injected spans/links pass through because HTML is enabled in the renderer.
+"""
+
+from __future__ import annotations
+
+import html
+
+from markdown_it import MarkdownIt
+
+from .model import Dictionary, Record
+
+# CommonMark renderer with raw-HTML passthrough (for the injected spans) and
+# linkify (bare URLs become links, matching the Java autolink extension). The
+# commonmark preset doesn't turn on the linkify *rule* by default, so enable it.
+_md = MarkdownIt("commonmark", {"html": True, "linkify": True}).enable("linkify")
+
+
+def _link_record_ids(text: str, dictionary: Dictionary) -> str:
+    """Turn `` `id` `` into a cross-reference link for every known record id."""
+    for record_id in dictionary.ids():
+        token = f"`{record_id}`"
+        link = f'<a href="#{record_id}" class="record__id badge">{record_id}</a>'
+        text = text.replace(token, link)
+    return text
+
+
+def _badge_choice_values(text: str, record: Record) -> str:
+    """Turn `` `value` `` into a badge for each of the record's choice values."""
+    for choice in record.choices:
+        token = f"`{choice.value}`"
+        extra = " choice__value--missing-value-code" if choice.is_missing_value_code else ""
+        badge = (
+            f'<span class="badge choice__value{extra}" '
+            f'title="{html.escape(choice.value, quote=True)}">{choice.value}</span>'
+        )
+        text = text.replace(token, badge)
+    return text
+
+
+def render_description(text: str, record: Record, dictionary: Dictionary) -> str:
+    """Enrich and render a record's description Markdown to an HTML string."""
+    if not text:
+        return ""
+    # Choice-value badges first: a choice value is more specific than an id, and
+    # linking ids afterwards won't match the already-substituted badge markup.
+    enriched = _badge_choice_values(text, record)
+    enriched = _link_record_ids(enriched, dictionary)
+    return _md.render(enriched)

--- a/printer/dd_printer/model.py
+++ b/printer/dd_printer/model.py
@@ -1,0 +1,72 @@
+"""The printer's neutral data-dictionary model.
+
+Plain dataclasses describing a dictionary for rendering: it has ordered
+sections, each with numbered records (data elements), each of which may carry an
+enumeration of choices. There is no dependency on any particular source format
+and no RADx-specific concepts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Choice:
+    """One permissible value of an enumerated field."""
+
+    value: str
+    label: str = ""
+    meaning: str | None = None  # ontology term identifier, if any
+    is_missing_value_code: bool = False
+
+
+@dataclass
+class Record:
+    """One data element (a field of the described datafile)."""
+
+    number: int  # 1-based position across the whole dictionary
+    id: str
+    label: str = ""
+    description: str = ""  # source Markdown (rendered to HTML at print time)
+    section: str = ""
+    datatype: str = ""
+    cardinality: str = ""  # "single" / "multiple"
+    unit: str = ""
+    pattern: str = ""
+    terms: list[str] = field(default_factory=list)
+    choices: list[Choice] = field(default_factory=list)  # the enumeration, if any
+    notes: str = ""
+    provenance: str = ""
+    see_also: str = ""
+
+    @property
+    def is_multivalued(self) -> bool:
+        return self.cardinality.strip().lower() == "multiple"
+
+    @property
+    def has_enumeration(self) -> bool:
+        return bool(self.choices)
+
+
+@dataclass
+class Section:
+    """A named group of records (a dictionary Section)."""
+
+    name: str
+    records: list[Record] = field(default_factory=list)
+
+
+@dataclass
+class Dictionary:
+    """A whole data dictionary, grouped into ordered sections."""
+
+    title: str
+    sections: list[Section] = field(default_factory=list)
+
+    @property
+    def records(self) -> list[Record]:
+        return [r for s in self.sections for r in s.records]
+
+    def ids(self) -> set[str]:
+        return {r.id for r in self.records}

--- a/printer/dd_printer/render_html.py
+++ b/printer/dd_printer/render_html.py
@@ -1,0 +1,31 @@
+"""Render the dictionary model to a self-contained HTML page."""
+
+from __future__ import annotations
+
+from importlib.resources import files
+
+from jinja2 import Environment, select_autoescape
+
+from .markdown import render_description
+from .model import Dictionary
+
+_TEMPLATE = files("dd_printer.templates").joinpath("dictionary.html.j2").read_text(
+    encoding="utf-8"
+)
+_CSS = files("dd_printer.static").joinpath("dictionary.css").read_text(encoding="utf-8")
+
+# The template injects pre-rendered HTML via `| safe`, so autoescape is on for
+# everything else (labels, ids, cell values) to prevent accidental HTML/markup.
+_env = Environment(autoescape=select_autoescape(default=True))
+
+
+def render_html(dictionary: Dictionary) -> str:
+    """Render the dictionary to a single self-contained HTML document."""
+    template = _env.from_string(_TEMPLATE)
+    # Attach rendered description/notes HTML to each record for the template.
+    for record in dictionary.records:
+        record.description_html = render_description(
+            record.description, record, dictionary
+        )
+        record.notes_html = render_description(record.notes, record, dictionary)
+    return template.render(dictionary=dictionary, css=_CSS)

--- a/printer/dd_printer/render_json.py
+++ b/printer/dd_printer/render_json.py
@@ -1,0 +1,17 @@
+"""Render the dictionary model to JSON."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+
+from .model import Dictionary
+
+
+def render_json(dictionary: Dictionary, *, indent: int = 2) -> str:
+    """Serialise the dictionary model to a pretty-printed JSON string.
+
+    Computed properties (``is_multivalued``, ``has_enumeration``) are dropped;
+    only the stored fields are emitted, so the JSON mirrors the model structure.
+    """
+    return json.dumps(dataclasses.asdict(dictionary), indent=indent, ensure_ascii=False)

--- a/printer/dd_printer/static/dictionary.css
+++ b/printer/dd_printer/static/dictionary.css
@@ -1,0 +1,148 @@
+:root {
+  /* Badge colours, from the original Java template. */
+  --data-element: #68b622;
+  --data-element-dark: #579a1d;
+  --facet: #eb944c;
+  --choice: #59aaf8;
+  --missing: #86878a;
+  --term: #9d7bdb;
+  /* Card/layout neutrals. */
+  --ink: #1f2933;
+  --muted: #6b7280;
+  --line: #e5e7eb;
+  --card: #ffffff;
+  --page: #f4f6f8;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  font-family: "Helvetica Neue", Helvetica, Arial, "Liberation Sans", sans-serif;
+  color: var(--ink);
+  line-height: 1.55;
+  margin: 0;
+  background: var(--page);
+}
+
+.container {
+  max-width: 940px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 4rem;
+}
+
+.title {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin: 0 0 1.5rem;
+}
+
+.section { margin-top: 2.5rem; }
+.section__name {
+  font-size: 1.15rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  margin: 0 0 1rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 2px solid var(--line);
+}
+
+/* Each data element is a card. */
+.record {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  box-shadow: 0 1px 3px rgba(16, 24, 40, 0.06);
+  padding: 0.5rem 1.25rem;
+  margin-bottom: 1.25rem;
+  scroll-margin-top: 1rem;
+}
+
+.record__table { border-collapse: collapse; width: 100%; }
+.record__table > tbody > tr { border-bottom: 1px solid #f1f3f5; }
+.record__table > tbody > tr:last-child { border-bottom: none; }
+.record__table th {
+  text-align: left;
+  vertical-align: top;
+  width: 9rem;
+  padding: 0.55rem 0.75rem 0.55rem 0;
+  color: var(--muted);
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+.record__table td { padding: 0.55rem 0; vertical-align: top; }
+
+.record__number {
+  color: var(--data-element);
+  font-weight: 700;
+  font-size: 1.05rem;
+}
+.record__label { font-size: 1.05rem; }
+
+.badge {
+  display: inline-block;
+  padding: 0.22em 0.6em;
+  font-size: 0.82em;
+  font-weight: 600;
+  line-height: 1.4;
+  border-radius: 0.4rem;
+  white-space: nowrap;
+  vertical-align: baseline;
+}
+.record__id,
+.record__description a.record__id,
+.record__notes a.record__id {
+  background: var(--data-element);
+  color: #fff;
+  text-decoration: none;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+a.record__id:hover { background: var(--data-element-dark); }
+.record__facet { background: var(--facet); color: #fff; }
+.term {
+  background: var(--term);
+  color: #fff;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.choice__value {
+  background: var(--choice);
+  color: #fff;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  min-width: 1.5rem;
+  text-align: center;
+}
+.choice__value--missing-value-code { background: var(--missing); }
+
+code {
+  background: #eef1f4;
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 0.9em;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+/* Enumeration: value badge + label per row. */
+.enumeration { border-collapse: collapse; }
+.enumeration td { padding: 0.2rem 0.75rem 0.2rem 0; vertical-align: middle; }
+.choice__label { color: var(--ink); }
+
+.record__description, .record__notes { max-width: 62ch; }
+.record__description :first-child,
+.record__notes :first-child { margin-top: 0; }
+.record__description :last-child,
+.record__notes :last-child { margin-bottom: 0; }
+.record__description a { color: var(--choice); }
+
+@media print {
+  body { background: #fff; }
+  html { font-size: 10.5px; }
+  a { text-decoration: none; }
+  .record {
+    break-inside: avoid;
+    box-shadow: none;
+    border-color: #d0d5dd;
+  }
+  .badge { border: none; }
+}

--- a/printer/dd_printer/templates/dictionary.html.j2
+++ b/printer/dd_printer/templates/dictionary.html.j2
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{ dictionary.title }}</title>
+<style>{{ css | safe }}</style>
+</head>
+<body>
+<div class="container">
+  <h1 class="title">{{ dictionary.title }}</h1>
+
+  {% for section in dictionary.sections %}
+  <section class="section">
+    <h2 class="section__name">{{ section.name }}</h2>
+
+    {% for record in section.records %}
+    <article class="record" id="{{ record.id }}">
+      <table class="record__table">
+        <tbody>
+          <tr>
+            <th class="record__number">{{ record.number }})</th>
+            <td><span class="badge record__id">{{ record.id }}</span></td>
+          </tr>
+          <tr><th>Label</th><td><strong class="record__label">{{ record.label }}</strong></td></tr>
+          {% if record.datatype %}
+          <tr><th>Datatype</th><td><span class="badge record__facet">{{ record.datatype }}</span></td></tr>
+          {% endif %}
+          {% if record.cardinality %}
+          <tr><th>Cardinality</th><td><span class="badge record__facet">{{ record.cardinality }}</span></td></tr>
+          {% endif %}
+          {% if record.unit %}
+          <tr><th>Unit</th><td><span class="badge record__facet">{{ record.unit }}</span></td></tr>
+          {% endif %}
+          {% if record.pattern %}
+          <tr><th>Pattern</th><td><code>{{ record.pattern }}</code></td></tr>
+          {% endif %}
+          {% if record.terms %}
+          <tr><th>Terms</th><td>
+            {% for term in record.terms %}<span class="badge term">{{ term }}</span> {% endfor %}
+          </td></tr>
+          {% endif %}
+          {% if record.description_html %}
+          <tr><th>Description</th><td class="record__description">{{ record.description_html | safe }}</td></tr>
+          {% endif %}
+          {% if record.choices %}
+          <tr><th>Enumeration</th><td>
+            <table class="enumeration">
+              <tbody>
+              {% for choice in record.choices %}
+                <tr>
+                  <td><span class="badge choice__value{% if choice.is_missing_value_code %} choice__value--missing-value-code{% endif %}">{{ choice.value }}</span></td>
+                  <td class="choice__label">{{ choice.label }}</td>
+                  {% if choice.meaning %}<td><span class="badge term">{{ choice.meaning }}</span></td>{% endif %}
+                </tr>
+              {% endfor %}
+              </tbody>
+            </table>
+          </td></tr>
+          {% endif %}
+          {% if record.notes_html %}
+          <tr><th>Notes</th><td class="record__notes">{{ record.notes_html | safe }}</td></tr>
+          {% endif %}
+        </tbody>
+      </table>
+    </article>
+    {% endfor %}
+  </section>
+  {% endfor %}
+</div>
+</body>
+</html>

--- a/printer/pyproject.toml
+++ b/printer/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dd-printer"
+version = "0.0.1"
+description = "Render a data dictionary to human-readable HTML or JSON"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "BSD-2-Clause" }
+dependencies = [
+    "jinja2>=3",
+    "markdown-it-py[linkify]>=3",
+    # The data-dictionary reader/loader is reused from the sibling converter.
+    # It is not on PyPI, so depend on it directly from this repository; this
+    # lets `pip/pipx install <printer>` pull the converter in one step.
+    "radx-dd-converter @ git+https://github.com/bmir-radx/radx-data-dictionary-specification.git#subdirectory=converter",
+]
+
+[project.optional-dependencies]
+test = ["pytest>=7"]
+
+[project.scripts]
+dd-print = "dd_printer.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["dd_printer*"]
+
+[tool.setuptools.package-data]
+dd_printer = ["templates/*.j2", "static/*.css"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/printer/tests/test_printer.py
+++ b/printer/tests/test_printer.py
@@ -1,0 +1,119 @@
+"""Tests for the data dictionary printer."""
+
+import io
+import json
+
+import pytest
+
+from dd_printer.load import load_dictionary
+from dd_printer.markdown import render_description
+from dd_printer.render_html import render_html
+from dd_printer.render_json import render_json
+
+SAMPLE = (
+    "Id,Label,Description,Section,Cardinality,Datatype,Terms,Enumeration,MissingValueCodes\n"
+    "age,Age,The **age** in years.,Demographics,single,integer,PATO:0000011,,\n"
+    'sex,Sex,See `age`. Value `0` is female.,Demographics,single,integer,,'
+    '"""0""=[Female] | ""1""=[Male]","""-9""=[Refused]"\n'
+    "sym,Symptoms,Reported symptoms,Clinical,multiple,string,,,\n"
+)
+
+
+def _load():
+    return load_dictionary(io.StringIO(SAMPLE), title="Demo")
+
+
+# --- loading / model -------------------------------------------------------
+
+def test_sections_grouped_in_order_and_numbered():
+    d = _load()
+    assert [s.name for s in d.sections] == ["Demographics", "Clinical"]
+    assert [r.number for r in d.records] == [1, 2, 3]
+    assert [r.id for r in d.records] == ["age", "sex", "sym"]
+
+
+def test_cardinality_and_enumeration_parsed():
+    d = _load()
+    by_id = {r.id: r for r in d.records}
+    assert by_id["sym"].is_multivalued is True
+    assert by_id["age"].is_multivalued is False
+    choices = by_id["sex"].choices
+    assert [(c.value, c.label) for c in choices] == [("0", "Female"), ("1", "Male")]
+
+
+def test_loads_from_linkml_schema():
+    # Round-trip the sample through the converter to a schema, then load that.
+    from radx_dd_converter import EmitOptions, emit_schema, read_data_dictionary
+
+    rows = read_data_dictionary(io.StringIO(SAMPLE))
+    schema_yaml = emit_schema(rows, EmitOptions(schema_name="demo", class_name="Record"))
+    d = load_dictionary(io.StringIO(schema_yaml))
+    assert [r.id for r in d.records] == ["age", "sex", "sym"]
+    assert {r.id for r in d.records if r.choices} == {"sex"}
+
+
+# --- markdown enrichment ---------------------------------------------------
+
+def test_description_renders_markdown_and_id_link():
+    d = _load()
+    sex = {r.id: r for r in d.records}["sex"]
+    html = render_description(sex.description, sex, d)
+    assert '<a href="#age" class="record__id badge">age</a>' in html  # id cross-ref
+    assert 'class="badge choice__value' in html  # `0` choice badge
+
+
+def test_missing_value_code_badge_class():
+    # A choice value that is a missing-value code gets the extra class. Put the
+    # code into the enumeration so it appears as a choice and is referenced.
+    csv = (
+        "Id,Label,Description,Datatype,Enumeration,MissingValueCodes\n"
+        'q,Q,Code `-9` means refused.,integer,"""-9""=[Refused]","""-9""=[Refused]"\n'
+    )
+    d = load_dictionary(io.StringIO(csv))
+    rec = d.records[0]
+    html = render_description(rec.description, rec, d)
+    assert "choice__value--missing-value-code" in html
+
+
+# --- renderers -------------------------------------------------------------
+
+def test_html_is_self_contained_and_has_cards():
+    html = render_html(_load())
+    assert "<style>" in html and "cdn" not in html.lower()  # inlined CSS, no CDN
+    assert html.count('class="record"') == 3
+    assert 'id="age"' in html and 'id="sex"' in html
+
+
+def test_json_structure():
+    data = json.loads(render_json(_load()))
+    assert data["title"] == "Demo"
+    assert [s["name"] for s in data["sections"]] == ["Demographics", "Clinical"]
+    sex = next(r for s in data["sections"] for r in s["records"] if r["id"] == "sex")
+    assert sex["choices"][0]["label"] == "Female"
+
+
+def test_cli_writes_html(tmp_path):
+    from dd_printer.cli import main
+
+    src = tmp_path / "d.csv"
+    src.write_text(SAMPLE)
+    out = tmp_path / "d.html"
+    assert main([str(src), "-o", str(out)]) == 0
+    assert '<article class="record"' in out.read_text()
+
+
+def test_cli_format_inferred_from_json_extension(tmp_path):
+    from dd_printer.cli import main
+
+    src = tmp_path / "d.csv"
+    src.write_text(SAMPLE)
+    out = tmp_path / "d.json"
+    assert main([str(src), "-o", str(out)]) == 0
+    json.loads(out.read_text())  # valid JSON
+
+
+def test_cli_missing_input_returns_2(capsys):
+    from dd_printer.cli import main
+
+    assert main(["/no/such/file.csv"]) == 2
+    assert "not found" in capsys.readouterr().err


### PR DESCRIPTION
A Python **data dictionary printer** in `printer/`, sibling to `converter/`. It renders a data dictionary into a human-readable, self-contained HTML page (or JSON). A port of the Java printer at `radx-data-dictionary-printer`, scoped to the core printing pipeline.

**De-branded / generic:** no "RADx" naming, and none of the RADx-specific mappings/harmonization subsystem (that's a separate future effort). Package `dd_printer`, command `dd-print`.

## What it does
- **Loads** a data dictionary from a **CSV** or a **LinkML schema** (auto-detected), reusing the converter's reader/parser. Groups records by section (numbered across the whole dictionary), parses enumerations into choices.
- **Renders**:
  - **HTML** — one self-contained file (CSS inlined, no CDN); each data element is a card with id, label, facet badges, terms, a Markdown-rendered description, and its enumeration. Backtick record ids in descriptions become in-page cross-links; backtick enumeration values become value badges (missing-value codes styled distinctly).
  - **JSON** — the sectioned model.
- **CLI**: `dd-print INPUT [-o OUT] [-f html|json] [--title T]`.

## Install / dependency note
Depends on `radx-dd-converter`, which isn't on PyPI, so `pyproject.toml` references it as a **direct git dependency** — a single `pipx install .../#subdirectory=printer` pulls both. Verified in a fresh venv that installing the printer alone pulls the converter and `dd-print` runs.

## Testing
10 tests (loading from CSV and from a LinkML schema, section grouping/numbering, Markdown enrichment, HTML self-containment, JSON structure, CLI). ruff-clean. Verified end-to-end on the committed gcb example.

Design/scope recorded in `printer/PRINTER_PLAN.md`; install/usage in `printer/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)