### PR TITLE
Make the shared missing-value codes pluggable

### DIFF
--- a/GENERALIZATION_PLAN.md
+++ b/GENERALIZATION_PLAN.md
@@ -1,0 +1,76 @@
+# Generalization Plan — make the data dictionary toolkit adoptable outside RADx
+
+> **Status:** Planning. Goal: keep this repository, but generalize the spec and
+> tools so they read and work as a general-purpose **data dictionary** toolkit
+> that others can adopt, with RADx as one user rather than the whole identity.
+> "Generalize in place" — no repo move, no PyPI (yet).
+
+## Decisions (settled)
+
+- **Rename packages & commands to neutral names** (drop `radx`):
+  - `radx_dd_converter` → **`dd_converter`**; dist `radx-dd-converter` → **`dd-converter`**;
+    commands `radx-dd-to-linkml` → **`dd-to-linkml`**, `linkml-to-radx-dd` → **`linkml-to-dd`**.
+  - printer: package stays `dd_printer`; command stays `dd-print` (already neutral);
+    dist `dd-printer` unchanged. Its dependency on the converter updates to the new name.
+- **Keep the repo name** `radx-data-dictionary-specification`. Renaming would
+  break every clone/install URL. Consequence: the install *URLs* still contain
+  `radx` (`git+https://…/radx-data-dictionary-specification.git#subdirectory=…`)
+  even though the installed command is `dd-to-linkml`. Acceptable for "in place".
+- **Missing-value codes become pluggable/optional.** The 25-code set is the only
+  RADx-specific *content*. Keep it as a built-in **default** an adopter can
+  replace, rather than a privileged constant. (Design below.)
+- **Generalize the prose** across spec + READMEs + plans so the framing is a
+  general toolkit; keep legitimate attribution (LICENSE copyright; "originally
+  developed for RADx"). The Markdown spec title/body stays RADx-attributed but
+  should note the format is general-purpose.
+
+## Pluggable missing-value codes (design)
+
+Currently `missing_values.py` hard-codes the 25 standard codes and the emitter
+always wires `StandardMissingValueCodes` into every enumerated slot's `any_of`.
+Generalize:
+
+- Keep the RADx set as a named built-in default (e.g. `DEFAULT_MISSING_VALUE_CODES`,
+  parsed from the same verbatim string) but stop implying it is *the* set.
+- Add an option (`EmitOptions.missing_value_codes: list[EnumItem] | None`) and a
+  CLI flag to **override** the set — supply codes from a file/string, or pass an
+  empty set to omit the shared missing-codes enum entirely.
+- The reverse converter and printer already read whatever enum is present, so
+  they need no code-set knowledge — only naming updates.
+
+## Rename mechanics (do carefully; this is the error-prone part)
+
+1. `git mv converter/radx_dd_converter converter/dd_converter`.
+2. Update every `radx_dd_converter` import (converter, printer, tests) → `dd_converter`.
+3. `pyproject.toml`: dist name, `[project.scripts]` entry points, package-find
+   include, the printer's git dependency URL (subdirectory unchanged).
+4. Rename entry-point functions' console names only (module `cli:main` / `reverse:main` unchanged).
+5. Reinstall editable; run the full suite + ruff after each package to catch a missed import.
+6. Regenerate the committed example schemas (headers mention the old command name).
+
+## Prose generalization (files to touch)
+
+Spec `radx-data-dictionary-specification.md`, root `README.md`, `converter/README.md`,
+`printer/README.md`, `linkml/CONVERTER_PLAN.md`, `printer/PRINTER_PLAN.md`, and
+inline comments that say "RADx" where it means "a" dictionary. Distinguish:
+- **Neutralize**: generic format/tool descriptions currently branded RADx.
+- **Keep**: historical attribution, the Canopy note, the missing-code set's RADx origin.
+
+## Suggested execution order (separate PRs)
+
+1. **Pluggable missing-value codes** (feature; behaviour-preserving default) —
+   smallest self-contained change, get it in first.
+2. **Rename packages/commands** (mechanical but broad) — its own PR; verify
+   installs + tests + ruff; regenerate examples.
+3. **Prose/docs generalization** — the spec + READMEs + plan docs.
+
+Each step: full test suite + ruff green, generated examples byte-checked, and
+verify the fresh-venv install still works (the printer's git-dependency URL).
+
+## Resolved
+
+- Spec title: **retitle** to "Data Dictionary Specification" with a short
+  RADx-origin note (the format is general-purpose; RADx is where it originated).
+- Missing-codes CLI override: **from a file** containing the enumeration-cell
+  grammar (`"code"=[label] | ...`), passed via a flag; an empty override omits
+  the shared missing-codes enum.

--- a/converter/examples/gcb.yaml
+++ b/converter/examples/gcb.yaml
@@ -411,7 +411,7 @@ enums:
         title: over 200
 
   StandardMissingValueCodes:  # 16 of 16 enums
-    description: The standard set of RADx missing-value codes, which always applies to a missing-value-coded
+    description: The shared set of missing-value codes that applies to every missing-value-coded
       field.
     permissible_values:
       '-9999':

--- a/converter/examples/rad.yaml
+++ b/converter/examples/rad.yaml
@@ -1705,7 +1705,7 @@ enums:
         title: inconclusive
 
   StandardMissingValueCodes:  # 65 of 65 enums
-    description: The standard set of RADx missing-value codes, which always applies to a missing-value-coded
+    description: The shared set of missing-value codes that applies to every missing-value-coded
       field.
     permissible_values:
       '-9999':

--- a/converter/radx_dd_converter/__init__.py
+++ b/converter/radx_dd_converter/__init__.py
@@ -20,6 +20,7 @@ from .missing_values import (
     STANDARD_ENUM_NAME,
     STANDARD_MISSING_VALUE_CODES,
     STANDARD_MISSING_VALUE_CODES_TEXT,
+    parse_missing_value_codes_file,
 )
 from .reader import (
     KNOWN_COLUMNS,
@@ -44,6 +45,7 @@ __all__ = [
     "STANDARD_ENUM_NAME",
     "STANDARD_MISSING_VALUE_CODES",
     "STANDARD_MISSING_VALUE_CODES_TEXT",
+    "parse_missing_value_codes_file",
     "UnitOfMeasure",
     "lookup_unit",
     "KNOWN_COLUMNS",

--- a/converter/radx_dd_converter/cli.py
+++ b/converter/radx_dd_converter/cli.py
@@ -104,6 +104,14 @@ def _build_parser() -> argparse.ArgumentParser:
         "pairs (capped, with a '(+N more)' overflow).",
     )
     parser.add_argument(
+        "--missing-value-codes",
+        type=Path,
+        default=None,
+        metavar="FILE",
+        help="Override the built-in missing-value codes with those in FILE (an "
+        'enumeration cell, `"code"=[label] | ...`). An empty file omits them.',
+    )
+    parser.add_argument(
         "--allow-duplicates",
         action="store_true",
         help="Do not fail on a duplicate Id; keep the first occurrence, skip "
@@ -123,6 +131,11 @@ def _resolve_options(args: argparse.Namespace) -> EmitOptions:
     class_name = args.class_name or _class_from_name(name)
     schema_id = args.schema_id or f"{DEFAULT_ID_BASE}/{name}"
     apikey = args.bioportal_apikey or os.environ.get("BIOPORTAL_API_KEY")
+    missing_codes = None
+    if args.missing_value_codes is not None:
+        from .missing_values import parse_missing_value_codes_file
+
+        missing_codes = parse_missing_value_codes_file(args.missing_value_codes)
     return EmitOptions(
         schema_id=schema_id,
         schema_name=name,
@@ -131,6 +144,7 @@ def _resolve_options(args: argparse.Namespace) -> EmitOptions:
         resolver=args.resolver,
         bioportal_apikey=apikey,
         annotate_enum_values=args.annotate_enum_values,
+        missing_value_codes=missing_codes,
     )
 
 

--- a/converter/radx_dd_converter/emit.py
+++ b/converter/radx_dd_converter/emit.py
@@ -155,6 +155,10 @@ class EmitOptions:
     resolver: str = "ols4"  # term-name resolver: "ols4" or "bioportal"
     bioportal_apikey: str | None = None  # required when resolver == "bioportal"
     annotate_enum_values: bool = False  # comment field-enum values after range:
+    # The shared missing-value codes wired into every enumerated slot. None uses
+    # the built-in default set; an empty list omits the shared enum entirely; a
+    # custom list replaces the default.
+    missing_value_codes: list | None = None
 
 
 class Emitter:
@@ -162,6 +166,12 @@ class Emitter:
 
     def __init__(self, options: EmitOptions | None = None):
         self.opts = options or EmitOptions()
+        # Resolve the shared missing-value code set once (default unless overridden).
+        self._missing_value_codes = (
+            self.opts.missing_value_codes
+            if self.opts.missing_value_codes is not None
+            else STANDARD_MISSING_VALUE_CODES
+        )
         self._prefixes: dict[str, str] = {}
         self._enum_by_signature: dict[str, str] = {}  # dedup identical enumerations
         self._terms: set = set()  # every term identifier emitted (for annotation)
@@ -249,10 +259,10 @@ class Emitter:
             return
         enum = EnumDefinition(
             name=STANDARD_ENUM_NAME,
-            description="The standard set of RADx missing-value codes, which "
-            "always applies to a missing-value-coded field.",
+            description="The shared set of missing-value codes that applies to "
+            "every missing-value-coded field.",
         )
-        for item in STANDARD_MISSING_VALUE_CODES:
+        for item in self._missing_value_codes:
             enum.permissible_values[item.value] = PermissibleValue(
                 text=item.value, title=item.label or None
             )
@@ -349,8 +359,10 @@ class Emitter:
             slot.annotations["value_datatype"] = row.get("Datatype")
 
             branches = [AnonymousSlotExpression(range=enum_name)]
-            self._ensure_standard_codes_enum(schema)
-            branches.append(AnonymousSlotExpression(range=STANDARD_ENUM_NAME))
+            # Wire in the shared missing-value codes, unless the set is empty.
+            if self._missing_value_codes:
+                self._ensure_standard_codes_enum(schema)
+                branches.append(AnonymousSlotExpression(range=STANDARD_ENUM_NAME))
             if field_codes:
                 field_codes_name = self._emit_enum(
                     schema, f"{row.id}MissingValueCodes", field_codes

--- a/converter/radx_dd_converter/missing_values.py
+++ b/converter/radx_dd_converter/missing_values.py
@@ -46,3 +46,17 @@ STANDARD_MISSING_VALUE_CODES: list[EnumItem] = parse_missing_value_codes(
 
 # The name of the shared enum the emitter generates for these codes.
 STANDARD_ENUM_NAME = "StandardMissingValueCodes"
+
+
+def parse_missing_value_codes_file(path) -> list[EnumItem]:
+    """Read a missing-value-codes override from a file.
+
+    The file contains the same enumeration-cell grammar as a ``MissingValueCodes``
+    cell (``"code"=[label] | ...``). Returns the parsed codes, which callers can
+    pass to the emitter to replace the built-in default set. An empty/blank file
+    yields an empty list (meaning "no shared missing-value-codes enum").
+    """
+    from pathlib import Path
+
+    text = Path(path).read_text(encoding="utf-8-sig")
+    return parse_missing_value_codes(text)

--- a/converter/tests/test_cli.py
+++ b/converter/tests/test_cli.py
@@ -106,3 +106,14 @@ def test_duplicate_id_fails_but_allow_duplicates_succeeds(tmp_path, capsys):
     schema = yaml.safe_load(out.read_text())
     attrs = list(schema["classes"].values())[0]["attributes"]
     assert list(attrs) == ["A"]  # duplicate collapsed to the first occurrence
+
+
+def test_missing_value_codes_flag(tmp_path):
+    dd = tmp_path / "d.csv"
+    dd.write_text('Id,Label,Datatype,Enumeration\nq,Q,integer,"""0""=[No] | ""1""=[Yes]"\n')
+    codes = tmp_path / "codes.txt"
+    codes.write_text('"-1"=[Refused]')
+    out = tmp_path / "out.yaml"
+    assert main([str(dd), "-o", str(out), "--missing-value-codes", str(codes)]) == 0
+    schema = yaml.safe_load(out.read_text())
+    assert list(schema["enums"]["StandardMissingValueCodes"]["permissible_values"]) == ["-1"]

--- a/converter/tests/test_emit.py
+++ b/converter/tests/test_emit.py
@@ -173,6 +173,44 @@ def test_standard_codes_enum_present_and_complete(schema):
     assert pvs["-9999"]["title"] == "Reason Unknown"
 
 
+_ENUM_CSV = 'Id,Label,Datatype,Enumeration\nq,Q,integer,"""0""=[No] | ""1""=[Yes]"\n'
+
+
+def test_missing_value_codes_override():
+    from radx_dd_converter.grammar import parse_missing_value_codes
+
+    custom = parse_missing_value_codes('"-1"=[Refused] | "-2"=[Unknown]')
+    schema = yaml.safe_load(
+        emit_schema(
+            read_data_dictionary(_csv(_ENUM_CSV)),
+            EmitOptions(schema_name="s", class_name="Record", missing_value_codes=custom),
+        )
+    )
+    pvs = schema["enums"]["StandardMissingValueCodes"]["permissible_values"]
+    assert list(pvs) == ["-1", "-2"]
+
+
+def test_missing_value_codes_empty_omits_shared_enum():
+    schema = yaml.safe_load(
+        emit_schema(
+            read_data_dictionary(_csv(_ENUM_CSV)),
+            EmitOptions(schema_name="s", class_name="Record", missing_value_codes=[]),
+        )
+    )
+    assert "StandardMissingValueCodes" not in schema["enums"]
+    ranges = [b["range"] for b in schema["classes"]["Record"]["attributes"]["q"]["any_of"]]
+    assert ranges == ["QEnum"]  # only the field enum, no shared missing-codes branch
+
+
+def test_parse_missing_value_codes_file(tmp_path):
+    from radx_dd_converter import parse_missing_value_codes_file
+
+    path = tmp_path / "codes.txt"
+    path.write_text('"-1"=[Refused] | "-2"=[Unknown]')
+    codes = parse_missing_value_codes_file(path)
+    assert [(c.value, c.label) for c in codes] == [("-1", "Refused"), ("-2", "Unknown")]
+
+
 def test_custom_type_emitted_for_timestamp():
     rows = read_data_dictionary(
         _csv("Id,Label,Datatype\nWhen,When,timestamp\n")
@@ -208,7 +246,7 @@ def test_pretty_rendering_preserves_content(schema_yaml):
     from linkml_runtime.dumpers import json_dumper
 
     from radx_dd_converter import read_data_dictionary
-    from radx_dd_converter.emit import Emitter, EmitOptions, _strip_type_keys
+    from radx_dd_converter.emit import EmitOptions, _strip_type_keys
 
     em = Emitter(EmitOptions(schema_id="https://example.org/s", schema_name="s",
                              class_name="Record"))


### PR DESCRIPTION
**Step 1 of generalizing the toolkit** for use outside RADx (plan in `GENERALIZATION_PLAN.md`, also added here). The 25 standard missing-value codes were the only genuinely RADx-specific *content* in the emitter; this makes them a replaceable default rather than a privileged constant.

## Changes
- `EmitOptions.missing_value_codes`: `None` → built-in default set (unchanged behaviour); a custom list → replaces the set; an empty list → omits the shared missing-codes enum and its `any_of` branch entirely.
- New CLI flag `--missing-value-codes FILE` (the file holds the enumeration-cell grammar, `"code"=[label] | ...`); `parse_missing_value_codes_file()` reads it.
- De-branded the shared enum's `description` ("shared set of missing-value codes…" instead of "standard set of RADx…"); regenerated the committed `gcb`/`rad` example schemas to match.

## Verification
Default behaviour is unchanged — the *only* output difference is that one description line (confirmed by diffing regenerated vs. committed examples). Both examples lint clean. **142 tests** (4 new: override, omit, file parse, CLI flag); ruff-clean.

Next steps in the plan (separate PRs): rename packages/commands to neutral names (`dd_converter` / `dd-to-linkml` / `linkml-to-dd`), then generalize the prose/spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)