### PR TITLE
Generalize the prose: de-brand the spec, docs, and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-# RADx Data Dictionary Specification
+# Data Dictionary Specification
 
-A specification for the CSV **data dictionaries** used in the RADx data hub. A
-data dictionary is a CSV file that describes the structure of another CSV file
-(a *datafile*): one row per field, giving each field's identifier, label,
-datatype, permissible values, units, ontology terms, and more.
+A specification for CSV **data dictionaries**. A data dictionary is a CSV file
+that describes the structure of another CSV file (a *datafile*): one row per
+field, giving each field's identifier, label, datatype, permissible values,
+units, ontology terms, and more.
 
-> **Note:** The RADx data hub has since evolved into
-> [Canopy](https://github.com/canopy-datahub), an open-source platform for
-> FAIR-aligned scientific data hubs.
+> **Origin:** This specification and toolkit were originally developed for the
+> [RADx](https://github.com/canopy-datahub) data hub (which has since evolved
+> into [Canopy](https://github.com/canopy-datahub), an open-source platform for
+> FAIR-aligned scientific data hubs). Some default value sets reflect that
+> origin, but the format itself is general-purpose and not specific to RADx.
 
 📄 **[Read the specification →](radx-data-dictionary-specification.md)**
 
@@ -39,10 +41,10 @@ Then convert in either direction:
 
 ```sh
 # Data dictionary CSV -> LinkML schema
-radx-dd-to-linkml my_dictionary.csv -o my_schema.yaml
+dd-to-linkml my_dictionary.csv -o my_schema.yaml
 
 # LinkML schema -> data dictionary CSV
-linkml-to-radx-dd my_schema.yaml -o my_dictionary.csv
+linkml-to-dd my_schema.yaml -o my_dictionary.csv
 ```
 
 The generated schema describes the *target datafile* — one slot per data

--- a/converter/README.md
+++ b/converter/README.md
@@ -1,6 +1,6 @@
-# RADx Data Dictionary → LinkML Converter
+# Data Dictionary → LinkML Converter
 
-`radx-dd-to-linkml` converts a [RADx data dictionary](../radx-data-dictionary-specification.md)
+`dd-to-linkml` converts a [data dictionary](../radx-data-dictionary-specification.md)
 CSV into a [LinkML](https://linkml.io) schema. The data dictionary *describes* a
 datafile; the generated schema is a formal, machine-processable description of
 that datafile that you can validate data against, generate documentation from,
@@ -25,7 +25,7 @@ On first use of pipx, its bin directory may not be on your `PATH` (pipx warns
 if so). Run `pipx ensurepath` once — then open a new terminal — to add it, after
 which the commands are available everywhere.
 
-Either way this installs the `radx-dd-to-linkml` and `linkml-to-radx-dd`
+Either way this installs the `dd-to-linkml` and `linkml-to-dd`
 commands and their dependencies (`linkml`, `lark`). If you have cloned the
 repository, `pip install ./converter` from the repo root works too.
 
@@ -34,13 +34,13 @@ repository, `pip install ./converter` from the repo root works too.
 Convert a data dictionary to a schema file:
 
 ```
-radx-dd-to-linkml my_dictionary.csv -o my_schema.yaml
+dd-to-linkml my_dictionary.csv -o my_schema.yaml
 ```
 
 With no `-o`, the schema is written to standard output, so you can pipe it:
 
 ```
-radx-dd-to-linkml my_dictionary.csv | less
+dd-to-linkml my_dictionary.csv | less
 ```
 
 ### Naming the schema
@@ -50,7 +50,7 @@ filename (`patient_data.csv` → name `patient_data`, class `PatientData`).
 Override any of them:
 
 ```
-radx-dd-to-linkml my_dictionary.csv -o my_schema.yaml \
+dd-to-linkml my_dictionary.csv -o my_schema.yaml \
     --name my_data --id https://example.org/my_data --class-name Record
 ```
 
@@ -74,8 +74,8 @@ resolved is left as a bare identifier. Choose the lookup service with
   variable (or `--bioportal-apikey`).
 
 ```
-radx-dd-to-linkml my_dictionary.csv -o out.yaml --annotate-terms
-BIOPORTAL_API_KEY=… radx-dd-to-linkml my_dictionary.csv -o out.yaml \
+dd-to-linkml my_dictionary.csv -o out.yaml --annotate-terms
+BIOPORTAL_API_KEY=… dd-to-linkml my_dictionary.csv -o out.yaml \
     --annotate-terms --resolver bioportal
 ```
 
@@ -87,7 +87,7 @@ BIOPORTAL_API_KEY=… radx-dd-to-linkml my_dictionary.csv -o out.yaml \
 | `--allow-duplicates` | Tolerate a repeated `Id` (keep the first, skip later ones) instead of failing. |
 | `-v`, `--verbose` | Show warnings (unresolved term lookups, non-OBO prefixes, skipped duplicates). |
 
-Run `radx-dd-to-linkml --help` for the complete list.
+Run `dd-to-linkml --help` for the complete list.
 
 ## What gets generated
 
@@ -114,7 +114,7 @@ column maps to a LinkML feature of the slot:
 ### Enumerations and missing-value codes
 
 A data element with an `Enumeration` becomes a generated enum, and the slot
-accepts **either** one of that enum's values **or** a standard RADx
+accepts **either** one of that enum's values **or** a standard
 missing-value code. For example, this data dictionary row:
 
 ```csv
@@ -159,11 +159,11 @@ sections) which data elements reference it.
 
 ## Reconstructing the dictionary (round-trip)
 
-The reverse tool `linkml-to-radx-dd` rebuilds a data dictionary CSV from a
+The reverse tool `linkml-to-dd` rebuilds a data dictionary CSV from a
 generated schema:
 
 ```
-linkml-to-radx-dd my_schema.yaml -o my_dictionary.csv
+linkml-to-dd my_schema.yaml -o my_dictionary.csv
 ```
 
 The round-trip (CSV → LinkML → CSV) is **semantic, not byte-exact**: the forward
@@ -187,7 +187,7 @@ schemas produced from them: [`gcb.dd.csv`](examples/gcb.dd.csv) →
 The pipeline is also importable:
 
 ```python
-from radx_dd_converter import read_data_dictionary, emit_schema, EmitOptions
+from dd_converter import read_data_dictionary, emit_schema, EmitOptions
 
 rows = read_data_dictionary("my_dictionary.csv")
 print(emit_schema(rows, EmitOptions(schema_name="my_data", class_name="Record")))

--- a/converter/dd_converter/__init__.py
+++ b/converter/dd_converter/__init__.py
@@ -1,7 +1,7 @@
-"""Converter from RADx data dictionary CSV to a LinkML schema.
+"""Converter from data dictionary CSV to a LinkML schema.
 
 This package is described in ``linkml/CONVERTER_PLAN.md``. The ``grammar``
-subpackage is the parser layer: it turns the in-cell mini-grammars used by RADx
+subpackage is the parser layer: it turns the in-cell mini-grammars used by
 data dictionaries (enumerations, missing-value codes, ontology term lists) into
 Python objects. It is the one piece that standard LinkML tooling cannot provide,
 because the structure is hidden inside string cells in a bespoke notation.

--- a/converter/dd_converter/cli.py
+++ b/converter/dd_converter/cli.py
@@ -1,4 +1,4 @@
-"""Command-line interface for the RADx data dictionary -> LinkML converter.
+"""Command-line interface for the data dictionary -> LinkML converter.
 
 Usage::
 
@@ -25,14 +25,14 @@ from .grammar import ParseError
 from .reader import ReadError, read_data_dictionary
 from .terms_lookup import LookupError_
 
-DEFAULT_ID_BASE = "https://w3id.org/radx"
+DEFAULT_ID_BASE = "https://example.org/data-dictionary"
 
 
 def _name_from_filename(path: Path) -> str:
     """Derive a schema name from an input filename.
 
     ``gcb.dd.csv`` -> ``gcb``; ``patient_data.csv`` -> ``patient_data``. Strips
-    a trailing ``.dd`` (a common RADx data-dictionary suffix) and sanitises to a
+    a trailing ``.dd`` (a common data-dictionary suffix) and sanitises to a
     LinkML-safe token.
     """
     stem = path.name
@@ -57,7 +57,7 @@ def _class_from_name(name: str) -> str:
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="dd-to-linkml",
-        description="Convert a RADx data dictionary CSV into a LinkML schema.",
+        description="Convert a data dictionary CSV into a LinkML schema.",
     )
     parser.add_argument("input", type=Path, help="Path to the data dictionary CSV.")
     parser.add_argument(

--- a/converter/dd_converter/datatypes.py
+++ b/converter/dd_converter/datatypes.py
@@ -1,6 +1,6 @@
-"""Map RADx / XSD datatype names to LinkML ranges.
+"""Map XSD datatype names to LinkML ranges.
 
-A RADx ``Datatype`` value is either a LinkML built-in range (returned directly)
+A ``Datatype`` value is either a LinkML built-in range (returned directly)
 or a datatype with no LinkML built-in, for which the converter must emit a
 custom ``type`` into the output schema's ``types:`` block so the schema is
 self-contained (see ``linkml/CONVERTER_PLAN.md``).
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-# --- Direct mappings: RADx/XSD name -> LinkML built-in range ---------------
+# --- Direct mappings: XSD name -> LinkML built-in range ---------------
 #
 # Grouped by target for readability. Every one of the 47 allowable datatype
 # names is accounted for either here or in CUSTOM_TYPES below.
@@ -64,7 +64,7 @@ BUILTIN_RANGES: dict[str, str] = {
 class CustomType:
     """A LinkML custom ``type`` the converter must emit for a datatype.
 
-    ``name`` is both the RADx datatype name and the emitted type name.
+    ``name`` is both the datatype name and the emitted type name.
     ``typeof`` is the base LinkML type it derives from. ``pattern`` is an
     optional lexical constraint. ``uri`` records the type's provenance
     (typically ``xsd:<name>``) so the emitted type is self-describing.
@@ -77,13 +77,13 @@ class CustomType:
     description: str | None = None
 
 
-# --- Custom types: RADx/XSD name -> CustomType spec ------------------------
+# --- Custom types: XSD name -> CustomType spec ------------------------
 #
-# XSD types with no LinkML built-in, plus the three RADx-specific names. The
+# XSD types with no LinkML built-in, plus three non-XSD extension names. The
 # emitter adds each USED custom type to the output schema's `types:` block.
 
 CUSTOM_TYPES: dict[str, CustomType] = {
-    # RADx-specific datatypes.
+    # Non-XSD extension datatypes.
     "date_mdy": CustomType(
         "date_mdy",
         typeof="date",
@@ -140,11 +140,11 @@ CUSTOM_TYPES: dict[str, CustomType] = {
 
 
 class UnknownDatatypeError(ValueError):
-    """Raised when a Datatype value is not a recognised RADx/XSD datatype name."""
+    """Raised when a Datatype value is not a recognised XSD datatype name."""
 
 
 def resolve_datatype(name: str) -> str | CustomType:
-    """Resolve a RADx ``Datatype`` name.
+    """Resolve a ``Datatype`` name.
 
     Returns either a LinkML built-in range name (``str``) that can be used
     directly as a slot ``range``, or a :class:`CustomType` that the emitter must
@@ -159,6 +159,6 @@ def resolve_datatype(name: str) -> str | CustomType:
         return CUSTOM_TYPES[name]
     raise UnknownDatatypeError(
         f"Unknown datatype name {name!r}. Datatype names are case-sensitive and "
-        f"must be an XML Schema datatype name or a RADx extension "
+        f"must be an XML Schema datatype name or a non-XSD extension "
         f"(date_mdy, date_dmy, timestamp)."
     )

--- a/converter/dd_converter/emit.py
+++ b/converter/dd_converter/emit.py
@@ -147,8 +147,8 @@ def _value_derived_enum_name(items: list[EnumItem]) -> str | None:
 class EmitOptions:
     """Options controlling schema identity (from CLI flags / filename)."""
 
-    schema_id: str = "https://w3id.org/radx/generated"
-    schema_name: str = "radx_generated"
+    schema_id: str = "https://example.org/data-dictionary/generated"
+    schema_name: str = "generated"
     class_name: str = "Record"
     default_prefix: str | None = None  # defaults to schema_name
     annotate_terms: bool = False  # look up ontology term names and add as comments
@@ -301,7 +301,7 @@ class Emitter:
         if row.get("Pattern"):
             slot.pattern = row.get("Pattern")
 
-        # Terms -> related_mappings. RADx Terms are subject-matter annotations
+        # Terms -> related_mappings. Terms are subject-matter annotations
         # (the concept a field relates to), not the slot's predicate URI, so
         # they map to related_mappings rather than slot_uri / exact_mappings.
         for term in parse_terms(row.get("Terms")):
@@ -571,7 +571,7 @@ _HEADER_COMMENT = """\
 #   * Machine-oriented annotations (`unit_raw`, `value_datatype`, `provenance`,
 #     `original_id`) appear at the end of each slot.
 #
-# See the RADx Data Dictionary Specification for the source field definitions:
+# See the Data Dictionary Specification for the source field definitions:
 # https://github.com/bmir-radx/radx-data-dictionary-specification
 """
 

--- a/converter/dd_converter/grammar/__init__.py
+++ b/converter/dd_converter/grammar/__init__.py
@@ -1,4 +1,4 @@
-"""Parser layer for the RADx data dictionary in-cell mini-grammars."""
+"""Parser layer for the data dictionary in-cell mini-grammars."""
 
 from .parse import (
     EnumItem,

--- a/converter/dd_converter/grammar/enumeration.lark
+++ b/converter/dd_converter/grammar/enumeration.lark
@@ -1,4 +1,4 @@
-// Grammar for the RADx enumeration / missing-value-codes cell syntax.
+// Grammar for the enumeration / missing-value-codes cell syntax.
 //
 // Mirrors the EBNF in radx-data-dictionary-specification.md, section
 // "Semantics of Enumeration Values":

--- a/converter/dd_converter/grammar/parse.py
+++ b/converter/dd_converter/grammar/parse.py
@@ -1,4 +1,4 @@
-"""Parse the RADx enumeration and missing-value-codes cell grammars.
+"""Parse the enumeration and missing-value-codes cell grammars.
 
 Both the ``Enumeration`` and ``MissingValueCodes`` fields use the same cell
 syntax::

--- a/converter/dd_converter/grammar/terms.py
+++ b/converter/dd_converter/grammar/terms.py
@@ -1,4 +1,4 @@
-"""Parse the RADx ``Terms`` cell into a list of ontology term identifiers.
+"""Parse the ``Terms`` cell into a list of ontology term identifiers.
 
 Per the specification, multiple term identifiers are separated by white space
 (space U+0020 or non-breaking space U+00A0) or newline characters (U+000A). Each

--- a/converter/dd_converter/missing_values.py
+++ b/converter/dd_converter/missing_values.py
@@ -1,4 +1,4 @@
-"""The standard set of RADx missing-value codes.
+"""The default set of missing-value codes (originally from RADx).
 
 Per the specification, this standard set of codes always applies to a
 ``MissingValueCodes`` field; any codes given in a field's cell *augment* it. The

--- a/converter/dd_converter/reader.py
+++ b/converter/dd_converter/reader.py
@@ -1,4 +1,4 @@
-"""Read a RADx data dictionary CSV into ordered rows.
+"""Read a data dictionary CSV into ordered rows.
 
 The reader parses the CSV per RFC 4180 (via the standard library ``csv``
 module), validates the header record, and returns an ordered list of

--- a/converter/dd_converter/reverse.py
+++ b/converter/dd_converter/reverse.py
@@ -1,4 +1,4 @@
-"""Reconstruct a RADx data dictionary CSV from a generated LinkML schema.
+"""Reconstruct a data dictionary CSV from a generated LinkML schema.
 
 This is the inverse of :mod:`emit`. It reads a schema produced by this converter
 and rebuilds the data dictionary, one row per slot of the root class, inverting
@@ -177,7 +177,7 @@ def main(argv=None) -> int:
 
     parser = argparse.ArgumentParser(
         prog="linkml-to-dd",
-        description="Reconstruct a RADx data dictionary CSV from a LinkML schema.",
+        description="Reconstruct a data dictionary CSV from a LinkML schema.",
     )
     parser.add_argument("input", type=Path, help="Path to the LinkML schema YAML.")
     parser.add_argument(

--- a/converter/dd_converter/units.py
+++ b/converter/dd_converter/units.py
@@ -1,6 +1,6 @@
-"""Built-in unit table for mapping a RADx ``Unit`` cell to a UnitOfMeasure.
+"""Built-in unit table for mapping a ``Unit`` cell to a UnitOfMeasure.
 
-RADx ``Unit`` values are free text (the specification provides no controlled
+``Unit`` values are free text (the specification provides no controlled
 list). This module carries the small table of common units from the
 specification's own example table, keyed by both unit name and symbol, so the
 converter can populate a structured LinkML ``unit:`` block (``descriptive_name``,

--- a/converter/examples/gcb.yaml
+++ b/converter/examples/gcb.yaml
@@ -15,11 +15,11 @@
 #   * Machine-oriented annotations (`unit_raw`, `value_datatype`, `provenance`,
 #     `original_id`) appear at the end of each slot.
 #
-# See the RADx Data Dictionary Specification for the source field definitions:
+# See the Data Dictionary Specification for the source field definitions:
 # https://github.com/bmir-radx/radx-data-dictionary-specification
 
 name: gcb
-id: https://w3id.org/radx/gcb
+id: https://example.org/data-dictionary/gcb
 imports:
 - linkml:types
 prefixes:

--- a/converter/examples/rad.yaml
+++ b/converter/examples/rad.yaml
@@ -15,11 +15,11 @@
 #   * Machine-oriented annotations (`unit_raw`, `value_datatype`, `provenance`,
 #     `original_id`) appear at the end of each slot.
 #
-# See the RADx Data Dictionary Specification for the source field definitions:
+# See the Data Dictionary Specification for the source field definitions:
 # https://github.com/bmir-radx/radx-data-dictionary-specification
 
 name: rad
-id: https://w3id.org/radx/rad
+id: https://example.org/data-dictionary/rad
 imports:
 - linkml:types
 prefixes:

--- a/converter/tests/test_cli.py
+++ b/converter/tests/test_cli.py
@@ -44,7 +44,7 @@ def test_writes_output_file_with_filename_defaults(tmp_path, capsys):
     assert rc == 0
     schema = yaml.safe_load(out.read_text())
     assert schema["name"] == "sample"
-    assert schema["id"] == "https://w3id.org/radx/sample"
+    assert schema["id"] == "https://example.org/data-dictionary/sample"
     assert list(schema["classes"]) == ["Sample"]  # CamelCase of "sample"
 
 

--- a/converter/tests/test_datatypes.py
+++ b/converter/tests/test_datatypes.py
@@ -1,4 +1,4 @@
-"""Tests for the RADx/XSD datatype -> LinkML range mapping."""
+"""Tests for the XSD datatype -> LinkML range mapping."""
 
 from pathlib import Path
 

--- a/linkml/CONVERTER_PLAN.md
+++ b/linkml/CONVERTER_PLAN.md
@@ -1,13 +1,13 @@
-# RADx Data Dictionary → LinkML Schema Converter — Design
+# Data Dictionary → LinkML Schema Converter — Design
 
 > **Status:** Implemented in [`../converter/`](../converter/) as the
-> `radx-dd-to-linkml` tool. This document is the design record: it explains what
+> `dd-to-linkml` tool. This document is the design record: it explains what
 > the converter does and why the mapping decisions were made. Where the code and
 > this document ever disagree, the code (and its tests) is authoritative.
 
 ## Goal
 
-The converter reads a RADx data dictionary in CSV format and emits a **LinkML
+The converter reads a data dictionary in CSV format and emits a **LinkML
 schema** describing the *target datafile* that the dictionary documents. Each
 data element (row) becomes a **slot**; the datafile as a whole becomes a
 **class** (default name `Record`).
@@ -15,7 +15,7 @@ data element (row) becomes a **slot**; the datafile as a whole becomes a
 This is *metamodeling*: the dictionary is metadata about a datafile, and the
 output schema is a formal description of that datafile's structure, suitable for
 validating the datafile with standard LinkML tooling — subject to the
-multi-value delimiter caveat noted under "Future work" (RADx bare `|` vs.
+multi-value delimiter caveat noted under "Future work" (bare `|` vs.
 LinkML's bracketed `[ | ]`).
 
 > Not in scope for v1 (but the parser core is shared with it): converting a data
@@ -27,7 +27,7 @@ LinkML's bracketed `[ | ]`).
 - **Input:** one data dictionary CSV file (RFC 4180), with the header record and
   columns defined in `radx-data-dictionary-specification.md`.
 - **Output:** one LinkML schema YAML file describing the target datafile.
-- **CLI:** `radx-dd-to-linkml INPUT.csv -o SCHEMA.yaml [--name ... --id ...]`
+- **CLI:** `dd-to-linkml INPUT.csv -o SCHEMA.yaml [--name ... --id ...]`
 
 ## Core mapping: dictionary row → LinkML slot
 
@@ -61,7 +61,7 @@ These are easy to conflate but operate at different levels:
 - **Schema-level `source:`** — metadata about the *output schema as a whole*.
   Set once, to the authoritative prose specification / repository it was derived
   from (as in `data-dictionary.yaml`: the GitHub repo). Not per-field.
-- **RADx `Provenance`** — a *per-field* dictionary column: where the *definition*
+- **`Provenance`** — a *per-field* dictionary column: where the *definition*
   of that field came from (typically a Common Data Element it is based on). Per
   the spec its value is *ideally* a URL to a CDE repository, but *may* also be a
   free-text unambiguous CDE name.
@@ -75,7 +75,7 @@ is set independently and is unaffected by this per-field mapping.
 
 ### Unit mapping (decided: native `unit:`, lookup-assisted)
 
-RADx `Unit` is a single **free-text** string (the spec provides no controlled
+`Unit` is a single **free-text** string (the spec provides no controlled
 list) — e.g. `mm`, `mg/dL`, `degrees Celsius`. LinkML has a native `unit:` slot
 whose range is `UnitOfMeasure`, with fields: `symbol`, `abbreviation`,
 `descriptive_name`, `exact_mappings`, `ucum_code`, `derivation`,
@@ -88,18 +88,18 @@ Mapping (decided — lookup-assisted):
   "common units" example table (23 rows: `millimeter`/`mm`/length …
   `moles per liter`/`mol/L`/concentration). Each entry maps a unit **name or
   symbol** → `{descriptive_name, symbol, ucum_code?}`.
-- If the RADx `Unit` value matches the table (by name **or** symbol), emit a
+- If the `Unit` value matches the table (by name **or** symbol), emit a
   populated `unit:` block (`descriptive_name` + `symbol`, plus `ucum_code` where
   known).
 - If it does **not** match, emit `unit: {symbol: <raw string>}` — `symbol` is the
-  fallback field, since RADx unit values are most often short symbols.
+  fallback field, since unit values are most often short symbols.
 - **In all cases**, also preserve the original cell verbatim as
   `annotations.unit_raw` so the un-normalized string is always recoverable and
   the mapping is lossless (a table match must never silently discard the raw
   input).
 
 Deliberately **not** doing UCUM validation / QUDT `has_quantity_kind` resolution
-in v1: RADx units are free-text and many will not be valid UCUM, so requiring a
+in v1: units are free-text and many will not be valid UCUM, so requiring a
 UCUM library would reject legitimate data. `ucum_code` is populated only for the
 table-known units. This can be revisited later.
 
@@ -126,9 +126,9 @@ the `subsets:` declarations were verified to survive schema materialization
 
 ## Datatype mapping (decided: emit custom LinkML types)
 
-Direct built-in mappings (RADx name → LinkML built-in range):
+Direct built-in mappings (datatype name → LinkML built-in range):
 
-| RADx / XSD | LinkML built-in |
+| Datatype name | LinkML built-in |
 |---|---|
 | `string`, `normalizedString`, `token`, `Name`, `NCName`, `language`, `NMTOKEN`, `QName`, etc. | `string` |
 | `integer`, `int`, `short`, `byte`, `long`, `nonNegativeInteger`, `positiveInteger`, `unsignedInt`, ... | `integer` |
@@ -144,7 +144,7 @@ Direct built-in mappings (RADx name → LinkML built-in range):
 Types with **no** LinkML built-in → the converter emits a **custom `type`** into
 the output schema's `types:` block, so the schema is self-contained:
 
-| RADx / XSD | Emitted custom type |
+| Datatype name | Emitted custom type |
 |---|---|
 | `date_mdy` | `typeof: date`, `pattern: '^\d{2}/\d{2}/\d{4}$'` (US mm/dd/yyyy) |
 | `date_dmy` | `typeof: date`, `pattern: '^\d{2}/\d{2}/\d{4}$'` (intl dd/mm/yyyy) |
@@ -152,7 +152,7 @@ the output schema's `types:` block, so the schema is self-contained:
 | `gYearMonth`, `gYear`, `gMonthDay`, `gDay`, `gMonth` | `typeof: string` + XSD `pattern`, `uri: xsd:<name>` |
 | `duration`, `hexBinary`, `base64Binary`, `NOTATION`, ID/IDREF(S)/ENTITY(IES) | `typeof: string`, `uri: xsd:<name>` |
 
-Every emitted custom type carries `uri: xsd:<name>` (or the RADx meaning) so the
+Every emitted custom type carries `uri: xsd:<name>` so the
 provenance of the type is explicit. Only the custom types *actually used* by the
 input are emitted.
 
@@ -211,13 +211,13 @@ This is why Option 3 (union at the slot) is used rather than enum inheritance.
 ## Architecture
 
 ```
-radx_dd_converter/
+dd_converter/
   reader.py        # RFC-4180 CSV -> list[Row]; validates required headers, ordering
   grammar/
     enumeration.lark   # EBNF from spec section "Semantics of Enumeration Values"
     parse.py           # cell string -> [EnumItem(value,label,iri?)]; also MissingValueCodes
     terms.py           # split Terms cell -> [iri|curie] (ws / NBSP / newline)
-  datatypes.py     # RADx datatype name -> LinkML range | CustomTypeSpec
+  datatypes.py     # datatype name -> LinkML range | CustomTypeSpec
   missing_values.py # the 25 standard missing-value codes (constant) -> StandardMissingValueCodes enum
   units.py         # built-in unit table (from the spec) -> UnitOfMeasure lookup by name/symbol
   emit.py          # rows + parsed cells -> linkml_runtime SchemaDefinition -> YAML
@@ -281,12 +281,12 @@ never alters the schema content.
    (`--id`, `--name`, `--class-name`); when a flag is omitted, derived from the
    input CSV filename (e.g. `patient_data.csv` → name `patient_data`, id under a
    default base, class `PatientData`). The default root class name, when nothing
-   else is given, is **`Record`**. No dictionary metadata row is assumed (RADx
+   else is given, is **`Record`**. No dictionary metadata row is assumed (these
    dictionaries have no standard metadata row).
 
 3. **Packaging (decided).** An installable Python package living in this
    repository under [`converter/`](../converter/), exposing the
-   `radx-dd-to-linkml` console script.
+   `dd-to-linkml` console script.
 
 ## Future work (not v1)
 
@@ -305,14 +305,14 @@ Future items:
   (`Enumeration`, `Terms`, `MissingValueCodes`) into nested objects — the one
   piece LinkML tooling cannot provide.
 - **Datafile CSV → data instances of the generated schema.** This is *almost*
-  free with stock `linkml-convert`, but **not entirely**: RADx multi-valued
+  free with stock `linkml-convert`, but **not entirely**: multi-valued
   cells use a **bare** pipe (`cough|headache`) whereas LinkML's CSV convention
   is a **bracketed** pipe (`[cough|headache]`), and LinkML's CSV reader does not
   split a bare-pipe (or space-separated) cell at all (see the tested note
   below). So this needs a small **delimiter-normalization** pre-processing step
-  (rewrite RADx bare-pipe cells to `[a|b|c]`, or a custom loader) before
+  (rewrite bare-pipe cells to `[a|b|c]`, or a custom loader) before
   `linkml-convert` can be used. It is not a no-op.
-- Reverse direction: LinkML schema → RADx data dictionary CSV.
+- Reverse direction: LinkML schema → data dictionary CSV.
 - **Alias uniqueness enforcement.** The reader rejects a duplicate `Id`, but does
   not yet check that an `Alias` never collides with another record's `Id` or
   alias (the spec's cross-dictionary uniqueness rule).
@@ -331,7 +331,7 @@ Verified empirically with `linkml-convert` on this machine:
   is emitted as `[cough|headache]` — pipe-separated **and wrapped in square
   brackets**.
 
-Consequence: RADx (bare `|`) and LinkML (bracketed `[ | ]`) multi-value cell
+Consequence: A bare-pipe dictionary (bare `|`) and LinkML (bracketed `[ | ]`) multi-value cell
 conventions are **not interchangeable**, even though both use the pipe
 character. Any datafile round-trip through stock LinkML tooling must normalize
 the delimiter first, or the values are silently mis-read as one string.

--- a/linkml/data-dictionary-csv.yaml
+++ b/linkml/data-dictionary-csv.yaml
@@ -1,4 +1,4 @@
-# CSV-faithful rendering of the RADx Data Dictionary Specification.
+# CSV-faithful rendering of the Data Dictionary Specification.
 #
 # This schema models a data dictionary EXACTLY as it appears on the wire: a
 # single CSV file in which each row is one DataElement and every column is a
@@ -21,9 +21,9 @@
 # https://github.com/perma-id/w3id.org before these URIs will resolve.
 id: https://w3id.org/radx/data-dictionary-csv
 name: radxdatadictionarycsv
-title: RADx Data Dictionary Schema (CSV-faithful)
+title: Data Dictionary Schema (CSV-faithful)
 description: >-
-  A CSV-faithful LinkML rendering of the RADx Data Dictionary Specification.
+  A CSV-faithful LinkML rendering of the Data Dictionary Specification.
   Each row of the CSV is one DataElement and every column is a single string
   cell; rich values (enumerations, missing-value codes, ontology terms) are
   encoded within a single cell using the grammars defined in the specification.
@@ -219,7 +219,7 @@ enums:
     description: >-
       The set of allowable datatype names. This is the set of XML Schema Part 2
       built-in datatype names (the 19 primitive datatypes and the 25 datatypes
-      derived from them), extended with the RADx-specific datatype names
+      derived from them), extended with the format-specific datatype names
       date_mdy, date_dmy and timestamp.
     permissible_values:
 
@@ -271,7 +271,7 @@ enums:
       unsignedByte:
       positiveInteger:
 
-      # RADx-specific datatype names
+      # format-specific datatype names (beyond XML Schema)
       date_mdy:
       date_dmy:
       timestamp:

--- a/linkml/data-dictionary.yaml
+++ b/linkml/data-dictionary.yaml
@@ -3,10 +3,10 @@
 # https://github.com/perma-id/w3id.org before these URIs will resolve.
 id: https://w3id.org/radx/data-dictionary
 name: radxdatadictionary
-title: RADx Data Dictionary Schema
+title: Data Dictionary Schema
 description: >-
-  A LinkML rendering of the RADx Data Dictionary Specification. It models a RADx
-  data dictionary as a list of DataElement records, each describing one field
+  A LinkML rendering of the Data Dictionary Specification. It models a data
+  dictionary as a list of DataElement records, each describing one field
   (column) of a target datafile. See the `source` for the authoritative prose
   specification.
 license: https://opensource.org/licenses/BSD-2-Clause
@@ -41,7 +41,7 @@ classes:
         description: >-
           The Id field in the data dictionary specifies an identifier for the
           datafile field being described. Datafile field identifiers are
-          strings. To cater for pre-existing RADx study data we do not impose
+          strings. To cater for pre-existing study data we do not impose
           any restrictions on the format or characters that make up a field
           identifier. Field identifiers may contain spaces.
 
@@ -264,7 +264,7 @@ enums:
     description: >-
       The set of allowable datatype names. This is the set of XML Schema Part 2
       built-in datatype names (the 19 primitive datatypes and the 25 datatypes
-      derived from them), extended with the RADx-specific datatype names
+      derived from them), extended with the format-specific datatype names
       date_mdy, date_dmy and timestamp.
     permissible_values:
 
@@ -316,7 +316,7 @@ enums:
       unsignedByte:
       positiveInteger:
 
-      # RADx-specific datatype names
+      # format-specific datatype names (beyond XML Schema)
       date_mdy:
       date_dmy:
       timestamp:

--- a/printer/PRINTER_PLAN.md
+++ b/printer/PRINTER_PLAN.md
@@ -13,7 +13,7 @@
 
 ## Goal
 
-Render a RADx data dictionary into human-readable output — primarily a
+Render a data dictionary into human-readable output — primarily a
 **self-contained HTML page** (and JSON), grouped by section, with each data
 element shown as a card: its id, label, facets (datatype, cardinality, unit,
 pattern), description (Markdown → HTML), and enumeration choices.
@@ -39,7 +39,7 @@ parts of `DescriptionGenerator`. **Do not port these.**
 ## Input (decided direction, confirm in first session)
 
 Read the **LinkML data dictionary schema** produced by `../converter/`
-(`radx-dd-to-linkml`), reusing the converter's reader/reverse code, rather than
+(`dd-to-linkml`), reusing the converter's reader/reverse code, rather than
 re-implementing a CSV parser. A data dictionary CSV can be printed by running it
 through the converter first (or we accept CSV directly via the converter's
 `read_data_dictionary`). This is the main reason the printer lives in this repo.
@@ -78,7 +78,7 @@ printer/
     static/dictionary.css   # extracted from template.html
   tests/
 ```
-Depends on: the local `radx_dd_converter` package, `markdown-it-py`, and Jinja2.
+Depends on: the local `dd_converter` package, `markdown-it-py`, and Jinja2.
 
 ## Resolved decisions
 

--- a/radx-data-dictionary-specification.md
+++ b/radx-data-dictionary-specification.md
@@ -1,4 +1,10 @@
-# RADx Data Dictionary Specification
+# Data Dictionary Specification
+
+> This is a general-purpose specification for CSV data dictionaries. It was
+> originally developed for the [RADx](https://github.com/canopy-datahub) data
+> hub, and some default value sets (e.g. the standard missing-value codes)
+> reflect that origin, but the format itself is not specific to RADx.
+
 
 ## Introduction
 
@@ -8,13 +14,13 @@ When data is stored in a tabular Comma Separated Values (CSV) file format, recor
 
 The table below shows an example CSV file that contains some data.  The data contains two records (orange boxes) made up of seven fields (blue boxes).   In this example, the field identifiers are:  `PartId`, `Date`, `Time`, `Age`, `Mental Status`, `FS LL`, and `FS RL`.  Thus, the 4th column contains `Age` fields.  In the first record (second row) the `Age` field has a field value of `67`.  In the second record (third row), the `FS RL` field value does not have a value and we say that this field is _blank_.
 
-All RADx datafiles SHOULD have header records.
+All datafiles SHOULD have header records.
 
 ![Records, Fields and Field Values](schematic.png)
 
-## RADx Data Dictionaries
+## Data Dictionaries
 
-A RADx _data dictionary_ is a Comma Separated Values (CSV) file that describes how RADx _data_ contained in another CSV file, a _datafile_, is structured.  A data dictionary CSV file contains EXACTLY ONE data dictionary.
+A _data dictionary_ is a Comma Separated Values (CSV) file that describes how _data_ contained in another CSV file, a _datafile_, is structured.  A data dictionary CSV file contains EXACTLY ONE data dictionary.
 
 A machine-processable [LinkML](https://linkml.io) rendering of this specification is available in the [`linkml/`](linkml/) folder of this repository (see the [`linkml/` README section](README.md#linkml-representation) for an overview).  This Markdown document remains the authoritative specification.
 
@@ -26,7 +32,7 @@ Data dictionaries may be created with tools such as Google Sheets or Microsoft E
 
 ## Data Dictionary Layout
 
-A data dictionary contains a list of records (known as _Data Elements_ in RADx terminology), represented as rows, that describe the sequence of fields in a target datafile.  There is exactly one data dictionary record per datafile field. 
+A data dictionary contains a list of records (known as _Data Elements_), represented as rows, that describe the sequence of fields in a target datafile.  There is exactly one data dictionary record per datafile field. 
 
 A data dictionary CSV file contains a header record plus _one record for each of the target datafile's fields_.  Since the target datafile's fields are in columns, this means a record in a data dictionary essentially describes a column in the target data file.  Thus, if the target datafile has five columns in it, the data dictionary will contain _six_ records – one header record plus five non-header records that describe the five datafile fields.
 
@@ -60,7 +66,7 @@ Each record in a data dictionary SHOULD contain the following, possibly empty, f
 
 __Value Status__: REQUIRED (the value for the `Id` field MUST NOT be empty)
 
-The `Id` field in the data dictionary specifies an identifier for the datafile field being described.  Datafile field identifiers are strings.  To cater for pre-existing RADx study data we do not impose any restrictions on the format or characters that make up a field identifier.  Field identifiers may contain spaces.
+The `Id` field in the data dictionary specifies an identifier for the datafile field being described.  Datafile field identifiers are strings.  To cater for pre-existing study data we do not impose any restrictions on the format or characters that make up a field identifier.  Field identifiers may contain spaces.
 
 ### Field: Aliases
 
@@ -116,7 +122,7 @@ This field is optional but we strongly encourage its use in order to make data m
 
 __Value Status__: REQUIRED (the value MUST NOT be empty)
 
-The `Datatype` field in the data dictionary specifies a datatype name that types field values.  Datatype names MUST be from the set of allowable datatype names.  This set is defined as the set of [XML schema datatype](https://www.w3.org/TR/xmlschema-2/) names extended with a few datatype names, defined below, that cover US date formats (that are present in RADx data).  We use XML Schema Datatypes because this set of datatypes has precisely defined syntax and semantics.
+The `Datatype` field in the data dictionary specifies a datatype name that types field values.  Datatype names MUST be from the set of allowable datatype names.  This set is defined as the set of [XML schema datatype](https://www.w3.org/TR/xmlschema-2/) names extended with a few datatype names, defined below, that cover US date formats.  We use XML Schema Datatypes because this set of datatypes has precisely defined syntax and semantics.
 
 If an enumeration is supplied to provide a list of controlled values, then the datatype name should be set as the datatype name of the values in the enumeration.  See the description of [Column: Enumeration](#field-enumeration).  For example, if an enumeration of `0 = Blood | 1 = Saliva` was specified for a field the datatype name for this field would be `integer`, since the values of this enumeration are integers.  Similarly, if an enumeration of `RBC = Red Blood Cells | WBC = White Blood Cells` is specified for a field then the datatype name for that field would be `string`, since the values of this enumeration are strings.  If the values of an enumeration are intended to represent boolean flags (for example `"0"=[No] | "1"=[Yes]`) then the datatype name `integer` should be used rather than `boolean`, since the enumeration values `0` and `1` are written as integers.
 
@@ -162,7 +168,7 @@ __Value Status__: OPTIONAL
 
 The `Unit` field in the data dictionary may be used to document the units for datafile values that represent quantities.
 
-Since there is no standardized list of units used for RADx studies we do not provide a controlled list of units here.  However, here are some common units that we have observed being used in RADx data dictionaries.
+Since there is no standardized list of units we do not provide a controlled list of units here.  However, here are some common units that we have observed being used in data dictionaries.
 
 | Unit name | Symbol | Dimension |
 | -- | -- | -- |
@@ -259,7 +265,7 @@ quotedString = ? A finite sequence of characters, which may include letters, num
 
 The online survey software [REDCap](https://www.project-redcap.org) has a syntax that supports choices for questions.  The syntax we use here is a more precisely specified while also being more general.  In particular, we support embedding semantic identifiers for choices where as REDCap syntax does not.  In addition to this, it is possible to produce choices using the REDCap software that cannot be round tripped using REDCap choices syntax (a REDCap data dictionary can be exported that cannot be reimported by REDCap).
 
-Given a string that represents a list of choices in the REDCap choices format, the following regular expression and regular expression replacement can be used to convert the string into a RADx Enumeration format.
+Given a string that represents a list of choices in the REDCap choices format, the following regular expression and regular expression replacement can be used to convert the string into the Enumeration format.
 
 Match,
 
@@ -318,7 +324,7 @@ The `SeeAlso` field may be used to hold a URL that, when resolved, provides furt
 
 ## Template
 
-While the format of a published RADx Data Dictionary MUST be CSV, tools like Google Sheets or Excel can be used for editing/producing the CSV file.  A Google Sheet template data dictionary may be found [here](https://docs.google.com/spreadsheets/d/1f5KcnCx7fEHcC8uSS5CB71-D-y51BDxFfGltSbj85iw/edit?usp=sharing).
+While the format of a published Data Dictionary MUST be CSV, tools like Google Sheets or Excel can be used for editing/producing the CSV file.  A Google Sheet template data dictionary may be found [here](https://docs.google.com/spreadsheets/d/1f5KcnCx7fEHcC8uSS5CB71-D-y51BDxFfGltSbj85iw/edit?usp=sharing).
 
 ## Ontology Term Identifiers
 


### PR DESCRIPTION
**Step 3 (final) of generalizing the toolkit** for use outside RADx (`GENERALIZATION_PLAN.md`). With the RADx-specific *content* made pluggable (#28) and the packages/commands renamed (#29), this neutralizes the remaining RADx-specific *naming* so the spec, docs, and code all read as a general-purpose data dictionary toolkit that originated with RADx.

## Changes
- **Spec** retitled to "Data Dictionary Specification" with a short RADx-origin note; generic "RADx <noun>" phrases neutralized.
- **Root + converter READMEs, both plan docs, both hand-written LinkML schema headers** — generic framing; stale command/package names updated to `dd-to-linkml` / `linkml-to-dd` / `dd-converter` / `dd_converter`.
- **Code docstrings/comments** de-branded; default schema `id`/`name` no longer under `w3id.org/radx` (now `example.org/data-dictionary`); the generated-schema header comment and the committed examples regenerated to match.

## Deliberately kept (attribution / structural)
- The Canopy note and link; the origin attribution in the spec and on the missing-value codes.
- The **repo-name** paths and install URLs (`radx-data-dictionary-specification`) — the repo isn't renamed.
- Structural schema identifiers in `linkml/*.yaml` (`id`, `source`, prefix), and references to the historical Java source repo in the printer plan.

## Verification
Ran an independent full-repo `grep -i radx` and confirmed every survivor is one of the above intended categories. **152 tests pass; ruff-clean; all four schemas (2 examples + 2 hand-written) lint clean; README fences balanced.**

This completes the "generalize in place" work (the tools/spec are neutral; the repo keeps its name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)