### PR TITLE
Add data dictionary validator tool (dd-validate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ units, ontology terms, and more.
 📄 **[Read the specification →](radx-data-dictionary-specification.md)**
 
 The Markdown specification is the authoritative document. The LinkML schemas and
-the tools below (a converter and a printer) are machine-processable renderings
-and tooling built on top of it.
+the tools below (a converter, a printer, and a validator) are machine-processable
+renderings and tooling built on top of it.
 
 ## Repository contents
 
@@ -24,6 +24,7 @@ and tooling built on top of it.
 | [`radx-data-dictionary-specification.md`](radx-data-dictionary-specification.md) | The authoritative specification. |
 | [`converter/`](converter/) | A Python tool that converts between a data dictionary CSV and a LinkML schema, in both directions. |
 | [`printer/`](printer/) | A Python tool that renders a data dictionary to a human-readable HTML page (or JSON). |
+| [`validator/`](validator/) | A Python tool that checks a data dictionary against the specification and reports violations. |
 | [`linkml/`](linkml/) | Hand-written [LinkML](https://linkml.io) renderings of the specification. |
 
 ## Converter
@@ -77,6 +78,23 @@ dd-print my_dictionary.csv -o my_dictionary.html
 ```
 
 See the [printer README](printer/README.md) for options and details.
+
+## Validator
+
+[`validator/`](validator/) checks a data dictionary CSV against the specification
+and reports every violation it finds — missing required columns, unknown datatype
+names, malformed enumerations and patterns, invalid cardinality, duplicate ids,
+and more — each with a severity (ERROR / WARNING / INFO) and a line number. It
+does not transform the dictionary; it tells you what is wrong.
+
+```sh
+pipx install "git+https://github.com/bmir-radx/radx-data-dictionary-specification.git#subdirectory=validator"
+
+dd-validate my_dictionary.csv
+```
+
+It exits non-zero when any error is found, so it can gate a CI build. See the
+[validator README](validator/README.md) for the full set of checks and options.
 
 ## Hand-written LinkML schemas
 

--- a/validator/README.md
+++ b/validator/README.md
@@ -1,0 +1,93 @@
+# Data Dictionary Validator
+
+`dd-validate` checks a data dictionary **CSV** against the
+[specification](../radx-data-dictionary-specification.md) and reports every
+violation it finds. It does not transform the dictionary — it tells you what is
+wrong, at which line, and how severe it is.
+
+Each finding has a severity:
+
+- **ERROR** — makes the dictionary invalid (a MUST in the specification).
+- **WARNING** — a SHOULD; the dictionary is still valid but could be improved.
+- **INFO** — an optional improvement.
+
+## What it checks
+
+| Check | Severity | Flags |
+| --- | --- | --- |
+| Required headers | ERROR | A required column (`Id`, `Label`, `Datatype`) is missing. |
+| Id present | ERROR | An `Id` cell is blank. |
+| Id leading whitespace | ERROR | An `Id` starts with a space. |
+| Id whitespace | INFO | An `Id` contains a space. |
+| Label present | WARNING | A `Label` cell is blank. |
+| Datatype present | ERROR | A `Datatype` cell is blank. |
+| Unknown datatype | ERROR | A `Datatype` name is not recognised (suggests a fix). |
+| Cardinality | ERROR | A `Cardinality` value is not `single` or `multiple`. |
+| Pattern | ERROR | A `Pattern` is not a valid regular expression. |
+| Enumeration | ERROR | An `Enumeration` cell does not parse. |
+| Missing value codes | ERROR | A `MissingValueCodes` cell does not parse. |
+| SeeAlso URL | ERROR | A `SeeAlso` value is not an absolute URL. |
+| Duplicate Id | ERROR | An `Id` appears on more than one row. |
+
+The datatype names, the enumeration grammar, and the missing-value-codes grammar
+are reused from the sibling [converter](../converter/), so the validator stays in
+lockstep with the converter and the specification. A check whose column is not in
+the header does nothing — an absent *optional* column is not a problem.
+
+## Install
+
+For a command-line tool, [`pipx`](https://pipx.pypa.io) is the recommended way to
+install it — it puts `dd-validate` on your `PATH` in its own isolated
+environment:
+
+```
+pipx install "git+https://github.com/bmir-radx/radx-data-dictionary-specification.git#subdirectory=validator"
+```
+
+On first use of pipx, its bin directory may not be on your `PATH` (pipx warns if
+so). Run `pipx ensurepath` once — then open a new terminal — to add it.
+
+The validator depends on the converter package (for its parsers); the command
+above pulls it in automatically. To install into an existing environment instead
+of an isolated one, use `pip` in place of `pipx`.
+
+## Use it
+
+```
+# Validate a dictionary; findings print to stdout, one per line
+dd-validate my_dictionary.csv
+
+# Validate every CSV in a directory
+dd-validate ./dictionaries/
+
+# Only show errors, ignoring warnings and info
+dd-validate my_dictionary.csv --levels ERROR
+
+# Machine-readable output
+dd-validate my_dictionary.csv -f json -o report.json
+```
+
+Options:
+
+| Option | Effect |
+| --- | --- |
+| `-o`, `--output` | Output file (default: stdout). |
+| `-f`, `--format` | `text`, `csv`, `tsv`, or `json` (default: `text`). |
+| `--levels` | Only report these levels, e.g. `--levels ERROR WARNING` (default: all). |
+| `--no-duplicate-check` | Do not check for duplicate `Id`s. |
+| `--exit-zero` | Always exit `0`, even when errors are found. |
+
+## Exit codes
+
+- `0` — no ERROR-level findings remain (after any `--levels` filter).
+- `1` — at least one ERROR was found. Use this to gate a CI build.
+- `2` — a usage error (input not found).
+
+Pass `--exit-zero` to always exit `0` regardless of findings.
+
+## Development
+
+```
+pip install -e "./validator[test]"
+pytest validator
+```

--- a/validator/VALIDATOR_PLAN.md
+++ b/validator/VALIDATOR_PLAN.md
@@ -1,0 +1,242 @@
+# Data Dictionary Validator — Plan
+
+A Python tool that validates a data dictionary CSV against the specification and
+**reports every problem it finds** (it does not transform). Third tool in this
+repo, sibling to `converter/` and `printer/`. Ported from the Java validator at
+`bmir-radx/radx-data-dictionary-validator`, but generic/de-branded from the
+start and reusing the `dd_converter` package for per-cell parsing.
+
+Package: `dd_validator`. Command: `dd-validate`.
+
+---
+
+## 1. What the Java validator does (the thing we're porting)
+
+The Java validator (package `edu.stanford.bmir.radx.datadictionary.lib`) is a set
+of independent `*ValidatorComponent` beans, each producing typed `*Result`
+violations. Its architecture is **collect-all, never fail-fast**: every check
+runs against every row and appends problems to one list, which is then sorted
+and written as a tabular report. Key properties we will preserve:
+
+- Each per-field check looks up its column by header name; **if the column is
+  absent it does nothing** (a missing optional column is not an error).
+- Blank cells are skipped by per-field checks (except the required-field checks).
+- **No cross-row checks** — no duplicate-Id detection, no uniqueness. Each row is
+  validated independently. (This is a deliberate difference from the converter's
+  reader, which *does* raise on duplicate Ids.)
+- Datatype validation is **name-only**: it checks the datatype *name* is known;
+  it never validates cell *values* against datatype regexes.
+- Three severity levels: **ERROR, WARNING, INFO**.
+- Report output is **tabular CSV or TSV only** (no JSON in the original).
+- **Exit code is always 0** in the original — findings do not change it.
+
+### Check inventory (Java component → severity → what it flags)
+
+| # | Check | Column | Severity | Flags |
+|---|-------|--------|----------|-------|
+| 1 | Required headers | header row | ERROR | A required column header is absent. Suggests a rename if a header matches case-insensitively. |
+| 2 | Id present | `Id` | ERROR | Row too short or Id blank. |
+| 3 | Id starts with whitespace | `Id` | ERROR | Id begins with an ASCII space. |
+| 4 | Id contains whitespace | `Id` | **INFO** | Id contains an ASCII space anywhere. (Both #3 and #4 can fire on the same cell.) |
+| 5 | Label present | `Label` | **WARNING** | Label blank ("strongly recommended"). |
+| 6 | Datatype present | `Datatype` | ERROR | Datatype blank. |
+| 7 | Unknown datatype name | `Datatype` | ERROR | Name not in the datatype set. Emits a "Did you mean …?" suggestion. |
+| 8 | Invalid cardinality | `Cardinality` | ERROR | Value not exactly `single` or `multiple`. |
+| 9 | Malformed pattern | `Pattern` | ERROR | Value is not a compilable regex; reports description + index. |
+| 10 | Malformed enumeration | `Enumeration` | ERROR | Value fails the enumeration grammar. |
+| 11 | Malformed missing value codes | `MissingValueCodes` | ERROR | Value fails the **same** enumeration grammar. |
+| 12 | Malformed SeeAlso URL | `SeeAlso` | ERROR | Value is not an absolute URI. |
+
+There is **no Unit/UCUM check** in the Java tool (only a TODO).
+
+---
+
+## 2. Decisions for the Python port
+
+Most of these mirror the Java tool. Where I depart from it, it's flagged
+**[DEPART]** with a reason, and the open ones are in §7 for you to confirm.
+
+### 2a. Reuse vs. reimplement
+
+We reuse `dd_converter`'s per-cell parsers — they already encode this repo's
+grammar and datatype set, so the validator stays in lockstep with the converter
+and spec instead of duplicating rules:
+
+- **Datatype name** → `resolve_datatype(name)`; catch `UnknownDatatypeError`.
+  This is name-membership (+ the custom-type resolution), matching the Java
+  name-only semantics. We do **not** validate cell values against regexes.
+- **Enumeration** → `grammar.parse_enumeration(cell)`; catch `ParseError`.
+- **MissingValueCodes** → `grammar.parse_missing_value_codes(cell)`; catch
+  `ParseError`. (In this repo these are separate functions; the Java tool shared
+  one grammar. Same effect.)
+- **Column vocabulary** → `dd_converter.KNOWN_COLUMNS` and `REQUIRED_COLUMNS`
+  (`Id, Label, Datatype`). This resolves the Java source's header-vocabulary
+  split (its `columns.csv` used `Meaning`/`Units` while the field components used
+  `Unit`/etc.) — we use the **single** canonical vocabulary from the spec.
+
+We do **not** reuse `read_data_dictionary`: it is fail-fast (raises on the first
+duplicate/blank/bad header) and a validator must collect all problems. Instead
+the validator reads the CSV at the raw level with the stdlib `csv` module —
+exactly as `reader._read` does — and runs the checks itself. So the reader's
+duplicate/blank *checks* are re-expressed here as collect-all findings, not
+reused as raising code.
+
+### 2b. Datatype suggestions
+
+Port the Java "Did you mean …?" suggestion: case-insensitive exact match against
+the known names, else a small fix map (`bit→boolean, text→string,
+number→decimal, email→string, zipcode→string, phone→string`). This lives in the
+validator (no `dd_converter` equivalent). Message includes the suggestion only
+when one is found.
+
+### 2c. Pattern check
+
+Compile with Python `re.compile`; catch `re.error`, report its message and
+`.pos` when available. **[DEPART]** Python regex error text/positions differ from
+Java's `PatternSyntaxException` — we do not attempt byte-for-byte parity, since
+the spec says patterns are XSD regexes and neither engine is the XSD engine; a
+"pattern does not compile" signal is what matters.
+
+### 2d. SeeAlso check
+
+Parse with `urllib.parse.urlsplit`; flag as malformed if it has no scheme
+(not absolute). Matches the Java "not absolute" semantics.
+
+### 2e. Whitespace-in-Id checks
+
+Reproduce faithfully: `startswith(" ")` → ERROR; `" " in id` → INFO; both may
+fire. ASCII space only (not tab), matching the original.
+
+### 2f. Severity model
+
+Three levels: `ERROR`, `WARNING`, `INFO` (an `enum.Enum`, ordered for sorting).
+Level is a constant per check, assigned as in the table in §1.
+
+### 2g. Cross-row checks — **[DEPART, opt-in]**
+
+The Java tool has none. But this repo's spec and converter treat duplicate Ids as
+an error, and duplicate detection is genuinely useful. Plan: implement a
+**duplicate-Id** check as an ERROR, but keep the port faithful by default is a
+judgment call — see §7 Q1. (Alias uniqueness and referential checks: out of
+scope for v1.)
+
+---
+
+## 3. Module layout
+
+```
+validator/
+  VALIDATOR_PLAN.md          (this file)
+  README.md
+  pyproject.toml             (name=dd-validate? see §5; console script dd-validate)
+  dd_validator/
+    __init__.py              (public API: Finding, Level, validate, __all__)
+    model.py                 (Level enum, Finding dataclass)
+    checks.py                (the individual check functions)
+    validate.py              (orchestrator: read CSV rows, run all checks, collect)
+    report.py                (render findings: text, csv, tsv, json)
+    cli.py                   (dd-validate CLI)
+  tests/
+    test_checks.py
+    test_validate.py
+    test_report.py
+    test_cli.py
+    fixtures/...
+```
+
+### `model.py`
+- `class Level(enum.Enum)`: `ERROR`, `WARNING`, `INFO` (with an int order for sort).
+- `@dataclass(frozen=True) class Finding`: `level: Level`, `check: str` (short
+  name, e.g. `"unknown-datatype"`), `message: str`, `line: int | None`
+  (1-based source line; `None` for whole-file/header findings), `column: str |
+  None`, `value: str | None` (offending cell). A `.sort_key` on
+  `(line or 0, level.order, check)`.
+
+### `checks.py`
+Each check is a function `(rows, header, columns_present) -> Iterable[Finding]`
+or a per-row helper. Named checks: `check_required_headers`, `check_id`,
+`check_label`, `check_datatype`, `check_cardinality`, `check_pattern`,
+`check_enumeration`, `check_missing_value_codes`, `check_see_also`, and
+(opt-in) `check_duplicate_ids`.
+
+### `validate.py`
+- `read_rows(source) -> tuple[list[str], list[RawRow]]` — raw CSV read (stdlib
+  `csv`, `utf-8-sig`, BOM strip), no raising on data problems. Mirrors
+  `reader._read` structure but collects nothing / raises only on truly
+  unreadable input (empty file → a single ERROR finding, not an exception).
+- `validate(source, *, levels=None, include_duplicate_check=...) -> list[Finding]`
+  — run every check, concatenate, sort. This is the public entry point.
+
+### `report.py`
+- `render(findings, fmt) -> str` for `fmt in {"text", "csv", "tsv", "json"}`.
+- **text** (default): human-friendly, `path:line: LEVEL check — message`.
+- **csv/tsv**: columns `File, Row, Level, Check, Message, Value`. **[DEPART]** We
+  fix the Java writer's 7-header/6-field mismatch (it printed a `Directory`
+  header with no data field) — our header and rows agree.
+- **json**: a list of finding objects (the Java tool had no JSON; added because
+  every other tool in this repo emits JSON and it's the machine-readable path).
+
+### `cli.py`
+`dd-validate INPUT [-o OUTPUT] [--format text|csv|tsv|json] [--levels ...]
+[--exit-nonzero-on-error]`. INPUT may be a file or a directory (walk `*.csv`,
+like the Java `--in`). See §6 for exit-code decision.
+
+---
+
+## 4. Reuse summary (what comes from `dd_converter`)
+
+| Need | Source | Behavior |
+|------|--------|----------|
+| Column vocabulary | `KNOWN_COLUMNS`, `REQUIRED_COLUMNS` | canonical spec columns |
+| Datatype name check | `resolve_datatype` / `UnknownDatatypeError` | name-only membership |
+| Enumeration grammar | `grammar.parse_enumeration` / `ParseError` | catch per cell |
+| Missing value codes grammar | `grammar.parse_missing_value_codes` / `ParseError` | catch per cell |
+| CSV read shape | (pattern from) `reader._read` | reimplemented as collect-all |
+
+Datatype suggestion map, pattern compile, SeeAlso URL, whitespace-in-Id, and
+cardinality checks have **no** `dd_converter` equivalent → implemented in
+`checks.py`.
+
+---
+
+## 5. Packaging
+
+Follows the printer exactly:
+- `name = "dd-validate"`, `version = "0.0.1"`, `requires-python = ">=3.9"`,
+  BSD-2-Clause.
+- Dependency on the converter via the same direct-git pattern:
+  `dd-converter @ git+https://github.com/bmir-radx/radx-data-dictionary-specification.git#subdirectory=converter`.
+- `[project.scripts] dd-validate = "dd_validator.cli:main"`.
+- ruff config identical to the other packages (F,E,W,B,C4,UP,SIM @ 100 cols),
+  `from __future__ import annotations`, modern type hints, pytest tests.
+
+---
+
+## 6. Exit codes
+
+The Java tool always returns 0. **[DEPART, default-on]** Proposed:
+- `0` — no findings at/above the reporting threshold.
+- `1` — findings present (default gate: any ERROR).
+- `2` — usage error (input not found, unreadable), matching converter/printer.
+
+Rationale: a validator invoked in CI is expected to fail the build on errors;
+always-0 makes it useless as a gate. `--exit-zero` can restore the Java behavior.
+This is Q2 in §7.
+
+---
+
+## 7. Open questions for you
+
+1. **Duplicate-Id check.** The Java validator has no cross-row checks, but this
+   repo's converter treats duplicate Ids as fatal. Include a duplicate-Id check
+   (as an ERROR) in v1? *Recommend: yes* — it's the one cross-row rule the spec
+   clearly implies, and it's cheap.
+2. **Exit codes.** Gate exit status on findings (exit 1 on any ERROR) as above,
+   or stay faithful to the Java always-0? *Recommend: gate on ERROR*, with
+   `--exit-zero` to opt out.
+3. **Default output format.** Java defaults to TSV. This repo's other tools are
+   human-first (printer → HTML) with JSON as the machine path. *Recommend:
+   `text` default for a person at a terminal; `csv/tsv/json` on request.*
+4. **Command/package name.** `dd-validate` (verb) vs `dd-validator` (noun) —
+   the other two are verbs (`dd-print`) and nouns-as-packages (`dd_printer`).
+   *Recommend: command `dd-validate`, package `dd_validator`.*

--- a/validator/dd_validator/__init__.py
+++ b/validator/dd_validator/__init__.py
@@ -1,0 +1,23 @@
+"""Validate a data dictionary CSV against the specification.
+
+This package reports *every* violation it finds rather than transforming the
+dictionary. It is described in ``VALIDATOR_PLAN.md``. The per-cell parsing rules
+(datatype names, the enumeration and missing-value-codes grammars) are reused
+from the sibling :mod:`dd_converter` package so the validator stays in lockstep
+with the converter and the specification.
+"""
+
+from .model import Finding, Level
+from .report import FORMATS, render
+from .rows import RawRow, read_rows
+from .validate import validate
+
+__all__ = [
+    "Finding",
+    "Level",
+    "FORMATS",
+    "render",
+    "RawRow",
+    "read_rows",
+    "validate",
+]

--- a/validator/dd_validator/checks.py
+++ b/validator/dd_validator/checks.py
@@ -1,0 +1,261 @@
+"""The individual validation checks.
+
+Each check inspects the header or the data rows and yields :class:`Finding`
+objects. The checks are independent and never raise on a data problem; they
+report it. The per-cell parsing rules (datatype names, the enumeration and
+missing-value-codes grammars) are reused from :mod:`dd_converter` so the
+validator stays in lockstep with the converter and the specification.
+
+Conventions, mirrored from the reference Java validator:
+
+* A per-field check whose column is absent from the header does nothing (a
+  missing *optional* column is not itself a problem; missing *required* columns
+  are reported by :func:`check_required_headers`).
+* Per-field checks skip blank cells, except the required-field checks.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Sequence
+from urllib.parse import urlsplit
+
+from dd_converter import (
+    REQUIRED_COLUMNS,
+    UnknownDatatypeError,
+    resolve_datatype,
+)
+from dd_converter.grammar import (
+    ParseError,
+    parse_enumeration,
+    parse_missing_value_codes,
+)
+
+from .model import Finding, Level
+from .rows import RawRow
+
+# Known datatype names, for the "did you mean" suggestion. Resolving a name is
+# the source of truth for validity; this set is only used to find a
+# case-insensitive near-match to suggest.
+_DATATYPE_FIXES = {
+    "bit": "boolean",
+    "text": "string",
+    "number": "decimal",
+    "email": "string",
+    "zipcode": "string",
+    "phone": "string",
+}
+
+
+def _suggest_datatype(name: str) -> str | None:
+    """Suggest a correct datatype name for an unknown ``name``, or ``None``.
+
+    First a case-insensitive exact match against the known names (catches a
+    miscased ``Integer``/``String``), then a small hardcoded fix map for common
+    non-XSD names. Mirrors the reference validator's ``getSuggestedName``.
+    """
+    from dd_converter.datatypes import BUILTIN_RANGES, CUSTOM_TYPES
+
+    known = {*BUILTIN_RANGES, *CUSTOM_TYPES}
+    lowered = {n.lower(): n for n in known}
+    if name.lower() in lowered:
+        return lowered[name.lower()]
+    return _DATATYPE_FIXES.get(name.lower())
+
+
+# --- header ----------------------------------------------------------------
+
+def check_required_headers(header: Sequence[str]) -> Iterable[Finding]:
+    """Report each required column header that is absent.
+
+    Suggests a rename when a header matches a required name case-insensitively
+    (e.g. ``id`` for ``Id``).
+    """
+    present = set(header)
+    lowered = {h.lower(): h for h in header}
+    for required in REQUIRED_COLUMNS:
+        if required in present:
+            continue
+        message = f"required column {required!r} is missing"
+        near = lowered.get(required.lower())
+        if near is not None:
+            message += f" (did you mean the column {near!r}?)"
+        yield Finding(Level.ERROR, "required-header", message, column=required)
+
+
+# --- per-row helpers -------------------------------------------------------
+
+def _cell(row: RawRow, column: str, columns_present: set[str]) -> str | None:
+    """Return the (stripped) cell for ``column``, or ``None`` if the column is
+    absent from the header entirely. A blank cell returns the empty string."""
+    if column not in columns_present:
+        return None
+    return row.get(column)
+
+
+def check_id(rows: Iterable[RawRow], columns_present: set[str]) -> Iterable[Finding]:
+    if "Id" not in columns_present:
+        return  # required-header check already reports the missing column
+    for row in rows:
+        raw = row.get("Id")
+        if raw.strip() == "":
+            yield Finding(Level.ERROR, "id-missing", "Id is missing", line=row.line, column="Id")
+            continue
+        if raw.startswith(" "):
+            yield Finding(
+                Level.ERROR, "id-leading-whitespace",
+                "Id starts with whitespace", line=row.line, column="Id", value=raw,
+            )
+        if " " in raw:
+            yield Finding(
+                Level.INFO, "id-whitespace",
+                "Id contains whitespace", line=row.line, column="Id", value=raw,
+            )
+
+
+def check_label(rows: Iterable[RawRow], columns_present: set[str]) -> Iterable[Finding]:
+    if "Label" not in columns_present:
+        return
+    for row in rows:
+        if row.get("Label").strip() == "":
+            yield Finding(
+                Level.WARNING, "label-missing",
+                "Label is missing (a label is strongly recommended)",
+                line=row.line, column="Label",
+            )
+
+
+def check_datatype(rows: Iterable[RawRow], columns_present: set[str]) -> Iterable[Finding]:
+    if "Datatype" not in columns_present:
+        return
+    for row in rows:
+        name = row.get("Datatype").strip()
+        if name == "":
+            yield Finding(
+                Level.ERROR, "datatype-missing",
+                "Datatype is missing", line=row.line, column="Datatype",
+            )
+            continue
+        try:
+            resolve_datatype(name)
+        except UnknownDatatypeError:
+            message = f"{name!r} is not a known datatype name"
+            suggestion = _suggest_datatype(name)
+            if suggestion is not None:
+                message += f" (did you mean {suggestion!r}?)"
+            yield Finding(
+                Level.ERROR, "unknown-datatype", message,
+                line=row.line, column="Datatype", value=name,
+            )
+
+
+def check_cardinality(rows: Iterable[RawRow], columns_present: set[str]) -> Iterable[Finding]:
+    if "Cardinality" not in columns_present:
+        return
+    for row in rows:
+        value = row.get("Cardinality").strip()
+        if value == "":
+            continue
+        if value not in ("single", "multiple"):
+            yield Finding(
+                Level.ERROR, "invalid-cardinality",
+                f"invalid cardinality {value!r} (expected 'single' or 'multiple')",
+                line=row.line, column="Cardinality", value=value,
+            )
+
+
+def check_pattern(rows: Iterable[RawRow], columns_present: set[str]) -> Iterable[Finding]:
+    if "Pattern" not in columns_present:
+        return
+    for row in rows:
+        value = row.get("Pattern")
+        if value.strip() == "":
+            continue
+        try:
+            re.compile(value)
+        except re.error as exc:
+            yield Finding(
+                Level.ERROR, "malformed-pattern",
+                f"pattern is not a valid regular expression: {exc}",
+                line=row.line, column="Pattern", value=value,
+            )
+
+
+def check_enumeration(rows: Iterable[RawRow], columns_present: set[str]) -> Iterable[Finding]:
+    if "Enumeration" not in columns_present:
+        return
+    for row in rows:
+        value = row.get("Enumeration")
+        if value.strip() == "":
+            continue
+        try:
+            parse_enumeration(value)
+        except ParseError as exc:
+            yield Finding(
+                Level.ERROR, "malformed-enumeration",
+                f"enumeration is malformed: {exc}",
+                line=row.line, column="Enumeration", value=value,
+            )
+
+
+def check_missing_value_codes(
+    rows: Iterable[RawRow], columns_present: set[str]
+) -> Iterable[Finding]:
+    if "MissingValueCodes" not in columns_present:
+        return
+    for row in rows:
+        value = row.get("MissingValueCodes")
+        if value.strip() == "":
+            continue
+        try:
+            parse_missing_value_codes(value)
+        except ParseError as exc:
+            yield Finding(
+                Level.ERROR, "malformed-missing-value-codes",
+                f"missing value codes are malformed: {exc}",
+                line=row.line, column="MissingValueCodes", value=value,
+            )
+
+
+def check_see_also(rows: Iterable[RawRow], columns_present: set[str]) -> Iterable[Finding]:
+    if "SeeAlso" not in columns_present:
+        return
+    for row in rows:
+        value = row.get("SeeAlso").strip()
+        if value == "":
+            continue
+        # An absolute URL must have a scheme (e.g. https). urlsplit does not
+        # raise on ordinary strings, so we check the parsed scheme directly.
+        if not urlsplit(value).scheme:
+            yield Finding(
+                Level.ERROR, "malformed-see-also",
+                "SeeAlso is not an absolute URL",
+                line=row.line, column="SeeAlso", value=value,
+            )
+
+
+def check_duplicate_ids(
+    rows: Iterable[RawRow], columns_present: set[str]
+) -> Iterable[Finding]:
+    """Report Ids that appear on more than one row.
+
+    Not present in the reference Java validator, but the specification treats an
+    Id as the unique identifier of a data element, and the converter refuses a
+    dictionary with duplicate Ids. Reported against the *second and subsequent*
+    occurrences, naming the first.
+    """
+    if "Id" not in columns_present:
+        return
+    first_seen: dict[str, int] = {}
+    for row in rows:
+        row_id = row.get("Id").strip()
+        if row_id == "":
+            continue
+        if row_id in first_seen:
+            yield Finding(
+                Level.ERROR, "duplicate-id",
+                f"duplicate Id {row_id!r} (first seen on line {first_seen[row_id]})",
+                line=row.line, column="Id", value=row_id,
+            )
+        else:
+            first_seen[row_id] = row.line

--- a/validator/dd_validator/checks.py
+++ b/validator/dd_validator/checks.py
@@ -21,6 +21,8 @@ from collections.abc import Iterable, Sequence
 from urllib.parse import urlsplit
 
 from dd_converter import (
+    BUILTIN_RANGES,
+    CUSTOM_TYPES,
     REQUIRED_COLUMNS,
     UnknownDatatypeError,
     resolve_datatype,
@@ -34,9 +36,15 @@ from dd_converter.grammar import (
 from .model import Finding, Level
 from .rows import RawRow
 
-# Known datatype names, for the "did you mean" suggestion. Resolving a name is
-# the source of truth for validity; this set is only used to find a
-# case-insensitive near-match to suggest.
+# Case-insensitive index of the valid datatype names, used to recover the
+# correctly-cased name from a near-miss (e.g. "Integer" -> "integer").
+# resolve_datatype() remains the source of truth for what is valid.
+_DATATYPES_BY_LOWERCASE = {
+    name.lower(): name for name in (*BUILTIN_RANGES, *CUSTOM_TYPES)
+}
+
+# Datatype names people commonly write that are not in the specification, and
+# the valid name each one usually means. From the reference Java validator.
 _DATATYPE_FIXES = {
     "bit": "boolean",
     "text": "string",
@@ -47,20 +55,14 @@ _DATATYPE_FIXES = {
 }
 
 
-def _suggest_datatype(name: str) -> str | None:
-    """Suggest a correct datatype name for an unknown ``name``, or ``None``.
+def _suggest_datatype(unknown_name: str) -> str | None:
+    """Suggest a valid datatype name for an unknown one, or ``None``.
 
-    First a case-insensitive exact match against the known names (catches a
-    miscased ``Integer``/``String``), then a small hardcoded fix map for common
-    non-XSD names. Mirrors the reference validator's ``getSuggestedName``.
+    Tries a case-insensitive match against the valid names first (catches a
+    miscased ``Integer``), then the common-mistake fix map.
     """
-    from dd_converter.datatypes import BUILTIN_RANGES, CUSTOM_TYPES
-
-    known = {*BUILTIN_RANGES, *CUSTOM_TYPES}
-    lowered = {n.lower(): n for n in known}
-    if name.lower() in lowered:
-        return lowered[name.lower()]
-    return _DATATYPE_FIXES.get(name.lower())
+    lowered = unknown_name.lower()
+    return _DATATYPES_BY_LOWERCASE.get(lowered) or _DATATYPE_FIXES.get(lowered)
 
 
 # --- header ----------------------------------------------------------------
@@ -72,44 +74,37 @@ def check_required_headers(header: Sequence[str]) -> Iterable[Finding]:
     (e.g. ``id`` for ``Id``).
     """
     present = set(header)
-    lowered = {h.lower(): h for h in header}
+    headers_by_lowercase = {h.lower(): h for h in header}
     for required in REQUIRED_COLUMNS:
         if required in present:
             continue
         message = f"required column {required!r} is missing"
-        near = lowered.get(required.lower())
-        if near is not None:
-            message += f" (did you mean the column {near!r}?)"
+        miscased = headers_by_lowercase.get(required.lower())
+        if miscased is not None:
+            message += f" (did you mean the column {miscased!r}?)"
         yield Finding(Level.ERROR, "required-header", message, column=required)
 
 
-# --- per-row helpers -------------------------------------------------------
-
-def _cell(row: RawRow, column: str, columns_present: set[str]) -> str | None:
-    """Return the (stripped) cell for ``column``, or ``None`` if the column is
-    absent from the header entirely. A blank cell returns the empty string."""
-    if column not in columns_present:
-        return None
-    return row.get(column)
-
+# --- per-row checks ---------------------------------------------------------
 
 def check_id(rows: Iterable[RawRow], columns_present: set[str]) -> Iterable[Finding]:
     if "Id" not in columns_present:
         return  # required-header check already reports the missing column
     for row in rows:
-        raw = row.get("Id")
-        if raw.strip() == "":
+        # Deliberately unstripped: the whitespace checks below inspect it.
+        id_cell = row.get("Id")
+        if id_cell.strip() == "":
             yield Finding(Level.ERROR, "id-missing", "Id is missing", line=row.line, column="Id")
             continue
-        if raw.startswith(" "):
+        if id_cell.startswith(" "):
             yield Finding(
                 Level.ERROR, "id-leading-whitespace",
-                "Id starts with whitespace", line=row.line, column="Id", value=raw,
+                "Id starts with whitespace", line=row.line, column="Id", value=id_cell,
             )
-        if " " in raw:
+        if " " in id_cell:
             yield Finding(
                 Level.INFO, "id-whitespace",
-                "Id contains whitespace", line=row.line, column="Id", value=raw,
+                "Id contains whitespace", line=row.line, column="Id", value=id_cell,
             )
 
 
@@ -129,23 +124,23 @@ def check_datatype(rows: Iterable[RawRow], columns_present: set[str]) -> Iterabl
     if "Datatype" not in columns_present:
         return
     for row in rows:
-        name = row.get("Datatype").strip()
-        if name == "":
+        datatype_name = row.get("Datatype").strip()
+        if datatype_name == "":
             yield Finding(
                 Level.ERROR, "datatype-missing",
                 "Datatype is missing", line=row.line, column="Datatype",
             )
             continue
         try:
-            resolve_datatype(name)
+            resolve_datatype(datatype_name)
         except UnknownDatatypeError:
-            message = f"{name!r} is not a known datatype name"
-            suggestion = _suggest_datatype(name)
+            message = f"{datatype_name!r} is not a known datatype name"
+            suggestion = _suggest_datatype(datatype_name)
             if suggestion is not None:
                 message += f" (did you mean {suggestion!r}?)"
             yield Finding(
                 Level.ERROR, "unknown-datatype", message,
-                line=row.line, column="Datatype", value=name,
+                line=row.line, column="Datatype", value=datatype_name,
             )
 
 
@@ -153,14 +148,14 @@ def check_cardinality(rows: Iterable[RawRow], columns_present: set[str]) -> Iter
     if "Cardinality" not in columns_present:
         return
     for row in rows:
-        value = row.get("Cardinality").strip()
-        if value == "":
+        cardinality = row.get("Cardinality").strip()
+        if cardinality == "":
             continue
-        if value not in ("single", "multiple"):
+        if cardinality not in ("single", "multiple"):
             yield Finding(
                 Level.ERROR, "invalid-cardinality",
-                f"invalid cardinality {value!r} (expected 'single' or 'multiple')",
-                line=row.line, column="Cardinality", value=value,
+                f"invalid cardinality {cardinality!r} (expected 'single' or 'multiple')",
+                line=row.line, column="Cardinality", value=cardinality,
             )
 
 
@@ -168,16 +163,16 @@ def check_pattern(rows: Iterable[RawRow], columns_present: set[str]) -> Iterable
     if "Pattern" not in columns_present:
         return
     for row in rows:
-        value = row.get("Pattern")
-        if value.strip() == "":
+        pattern = row.get("Pattern")
+        if pattern.strip() == "":
             continue
         try:
-            re.compile(value)
+            re.compile(pattern)
         except re.error as exc:
             yield Finding(
                 Level.ERROR, "malformed-pattern",
                 f"pattern is not a valid regular expression: {exc}",
-                line=row.line, column="Pattern", value=value,
+                line=row.line, column="Pattern", value=pattern,
             )
 
 
@@ -185,16 +180,16 @@ def check_enumeration(rows: Iterable[RawRow], columns_present: set[str]) -> Iter
     if "Enumeration" not in columns_present:
         return
     for row in rows:
-        value = row.get("Enumeration")
-        if value.strip() == "":
+        enumeration = row.get("Enumeration")
+        if enumeration.strip() == "":
             continue
         try:
-            parse_enumeration(value)
+            parse_enumeration(enumeration)
         except ParseError as exc:
             yield Finding(
                 Level.ERROR, "malformed-enumeration",
                 f"enumeration is malformed: {exc}",
-                line=row.line, column="Enumeration", value=value,
+                line=row.line, column="Enumeration", value=enumeration,
             )
 
 
@@ -204,16 +199,16 @@ def check_missing_value_codes(
     if "MissingValueCodes" not in columns_present:
         return
     for row in rows:
-        value = row.get("MissingValueCodes")
-        if value.strip() == "":
+        codes = row.get("MissingValueCodes")
+        if codes.strip() == "":
             continue
         try:
-            parse_missing_value_codes(value)
+            parse_missing_value_codes(codes)
         except ParseError as exc:
             yield Finding(
                 Level.ERROR, "malformed-missing-value-codes",
                 f"missing value codes are malformed: {exc}",
-                line=row.line, column="MissingValueCodes", value=value,
+                line=row.line, column="MissingValueCodes", value=codes,
             )
 
 
@@ -221,16 +216,16 @@ def check_see_also(rows: Iterable[RawRow], columns_present: set[str]) -> Iterabl
     if "SeeAlso" not in columns_present:
         return
     for row in rows:
-        value = row.get("SeeAlso").strip()
-        if value == "":
+        url = row.get("SeeAlso").strip()
+        if url == "":
             continue
         # An absolute URL must have a scheme (e.g. https). urlsplit does not
         # raise on ordinary strings, so we check the parsed scheme directly.
-        if not urlsplit(value).scheme:
+        if not urlsplit(url).scheme:
             yield Finding(
                 Level.ERROR, "malformed-see-also",
                 "SeeAlso is not an absolute URL",
-                line=row.line, column="SeeAlso", value=value,
+                line=row.line, column="SeeAlso", value=url,
             )
 
 
@@ -246,16 +241,16 @@ def check_duplicate_ids(
     """
     if "Id" not in columns_present:
         return
-    first_seen: dict[str, int] = {}
+    first_seen_line: dict[str, int] = {}
     for row in rows:
         row_id = row.get("Id").strip()
         if row_id == "":
             continue
-        if row_id in first_seen:
+        if row_id in first_seen_line:
             yield Finding(
                 Level.ERROR, "duplicate-id",
-                f"duplicate Id {row_id!r} (first seen on line {first_seen[row_id]})",
+                f"duplicate Id {row_id!r} (first seen on line {first_seen_line[row_id]})",
                 line=row.line, column="Id", value=row_id,
             )
         else:
-            first_seen[row_id] = row.line
+            first_seen_line[row_id] = row.line

--- a/validator/dd_validator/cli.py
+++ b/validator/dd_validator/cli.py
@@ -1,0 +1,121 @@
+"""Command-line interface: validate a data dictionary and report violations.
+
+Usage::
+
+    dd-validate INPUT [-o OUTPUT] [--format text|csv|tsv|json]
+                [--levels ERROR WARNING INFO] [--no-duplicate-check]
+                [--exit-zero]
+
+INPUT may be a single CSV file or a directory (every ``*.csv`` beneath it is
+validated). Output goes to stdout unless ``-o`` is given.
+
+Exit codes: ``0`` when no ERROR-level findings remain after filtering, ``1``
+when any ERROR is present, ``2`` on a usage error (input not found). Pass
+``--exit-zero`` to always exit ``0`` regardless of findings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from . import report
+from .model import Finding, Level
+from .validate import validate
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="dd-validate",
+        description="Validate a data dictionary CSV against the specification.",
+    )
+    parser.add_argument(
+        "input", type=Path, help="Data dictionary CSV, or a directory of CSVs."
+    )
+    parser.add_argument(
+        "-o", "--output", type=Path, default=None, help="Output file (default: stdout)."
+    )
+    parser.add_argument(
+        "-f", "--format", choices=report.FORMATS, default="text",
+        help="Report format (default: text).",
+    )
+    parser.add_argument(
+        "--levels", nargs="+", choices=[level.name for level in Level], default=None,
+        help="Only report these severity levels (default: all).",
+    )
+    parser.add_argument(
+        "--no-duplicate-check", action="store_true",
+        help="Do not check for duplicate Ids (matches the reference validator).",
+    )
+    parser.add_argument(
+        "--exit-zero", action="store_true",
+        help="Always exit 0, even when errors are found.",
+    )
+    return parser
+
+
+def _inputs(path: Path) -> list[Path]:
+    if path.is_dir():
+        return sorted(p for p in path.rglob("*.csv") if not p.name.startswith("."))
+    return [path]
+
+
+def main(argv=None) -> int:
+    args = _build_parser().parse_args(argv)
+    if not args.input.exists():
+        print(f"error: input not found: {args.input}", file=sys.stderr)
+        return 2
+
+    levels = {Level[name] for name in args.levels} if args.levels else None
+
+    sections: list[str] = []
+    all_findings: list[Finding] = []
+    for path in _inputs(args.input):
+        findings = validate(path, check_duplicate_ids=not args.no_duplicate_check)
+        if levels is not None:
+            findings = [f for f in findings if f.level in levels]
+        all_findings.extend(findings)
+        sections.append(report.render(findings, args.format, file=str(path)))
+
+    rendered = _join(sections, args.format)
+
+    if args.output is None:
+        sys.stdout.write(rendered)
+    else:
+        args.output.write_text(rendered, encoding="utf-8")
+
+    errors = sum(1 for f in all_findings if f.level is Level.ERROR)
+    print(
+        f"{len(all_findings)} finding(s), {errors} error(s).", file=sys.stderr
+    )
+
+    if args.exit_zero:
+        return 0
+    return 1 if errors else 0
+
+
+def _join(sections: list[str], fmt: str) -> str:
+    """Concatenate per-file report sections.
+
+    For the tabular formats each section carries its own header row; when
+    validating several files we keep the first header and drop the repeats so
+    the output is one table.
+    """
+    if fmt in ("csv", "tsv") and len(sections) > 1:
+        kept = []
+        header_seen = False
+        for section in sections:
+            lines = section.splitlines()
+            if not lines:
+                continue
+            if header_seen:
+                lines = lines[1:]  # drop the repeated header row
+            header_seen = True
+            kept.extend(lines)
+        return "\n".join(kept) + ("\n" if kept else "")
+    return "".join(sections)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/validator/dd_validator/cli.py
+++ b/validator/dd_validator/cli.py
@@ -55,7 +55,9 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _inputs(path: Path) -> list[Path]:
+def _input_files(path: Path) -> list[Path]:
+    """Return the CSV files to validate: the path itself, or every non-hidden
+    ``*.csv`` beneath it when it is a directory."""
     if path.is_dir():
         return sorted(p for p in path.rglob("*.csv") if not p.name.startswith("."))
     return [path]
@@ -69,52 +71,52 @@ def main(argv=None) -> int:
 
     levels = {Level[name] for name in args.levels} if args.levels else None
 
-    sections: list[str] = []
+    per_file_reports: list[str] = []
     all_findings: list[Finding] = []
-    for path in _inputs(args.input):
+    for path in _input_files(args.input):
         findings = validate(path, check_duplicate_ids=not args.no_duplicate_check)
         if levels is not None:
-            findings = [f for f in findings if f.level in levels]
+            findings = [finding for finding in findings if finding.level in levels]
         all_findings.extend(findings)
-        sections.append(report.render(findings, args.format, file=str(path)))
+        per_file_reports.append(report.render(findings, args.format, file=str(path)))
 
-    rendered = _join(sections, args.format)
+    rendered = _join_reports(per_file_reports, args.format)
 
     if args.output is None:
         sys.stdout.write(rendered)
     else:
         args.output.write_text(rendered, encoding="utf-8")
 
-    errors = sum(1 for f in all_findings if f.level is Level.ERROR)
+    error_count = sum(1 for finding in all_findings if finding.level is Level.ERROR)
     print(
-        f"{len(all_findings)} finding(s), {errors} error(s).", file=sys.stderr
+        f"{len(all_findings)} finding(s), {error_count} error(s).", file=sys.stderr
     )
 
     if args.exit_zero:
         return 0
-    return 1 if errors else 0
+    return 1 if error_count else 0
 
 
-def _join(sections: list[str], fmt: str) -> str:
-    """Concatenate per-file report sections.
+def _join_reports(per_file_reports: list[str], fmt: str) -> str:
+    """Concatenate per-file reports into one document.
 
-    For the tabular formats each section carries its own header row; when
-    validating several files we keep the first header and drop the repeats so
-    the output is one table.
+    Each tabular (csv/tsv) report carries its own header row; when several
+    files were validated, keep the first header and drop the repeats so the
+    result is a single table.
     """
-    if fmt in ("csv", "tsv") and len(sections) > 1:
-        kept = []
+    if fmt in ("csv", "tsv") and len(per_file_reports) > 1:
+        joined_lines: list[str] = []
         header_seen = False
-        for section in sections:
-            lines = section.splitlines()
+        for file_report in per_file_reports:
+            lines = file_report.splitlines()
             if not lines:
                 continue
             if header_seen:
                 lines = lines[1:]  # drop the repeated header row
             header_seen = True
-            kept.extend(lines)
-        return "\n".join(kept) + ("\n" if kept else "")
-    return "".join(sections)
+            joined_lines.extend(lines)
+        return "\n".join(joined_lines) + ("\n" if joined_lines else "")
+    return "".join(per_file_reports)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/validator/dd_validator/model.py
+++ b/validator/dd_validator/model.py
@@ -1,0 +1,56 @@
+"""The severity model and the finding record.
+
+A validator, unlike the converter's reader, must collect *every* problem rather
+than stop at the first. Each problem is a :class:`Finding`. Findings carry a
+:class:`Level` so a report can be filtered by severity and a caller can gate an
+exit code on the presence of errors.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+
+
+class Level(enum.Enum):
+    """Severity of a finding.
+
+    ``ERROR`` marks something that makes the dictionary invalid (a MUST in the
+    specification). ``WARNING`` marks a SHOULD — the dictionary is still valid.
+    ``INFO`` is an optional improvement. The associated integer orders levels
+    for sorting (most severe first) and is stable for reports.
+    """
+
+    ERROR = 0
+    WARNING = 1
+    INFO = 2
+
+    @property
+    def order(self) -> int:
+        return self.value
+
+    def __str__(self) -> str:
+        return self.name
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One validation problem.
+
+    ``check`` is a short stable identifier (e.g. ``"unknown-datatype"``).
+    ``line`` is the 1-based line in the source CSV, or ``None`` for a
+    whole-file / header finding. ``column`` and ``value`` locate the offending
+    cell when applicable.
+    """
+
+    level: Level
+    check: str
+    message: str
+    line: int | None = None
+    column: str | None = None
+    value: str | None = None
+
+    @property
+    def sort_key(self) -> tuple[int, int, str]:
+        """Order by source line, then severity, then check name."""
+        return (self.line or 0, self.level.order, self.check)

--- a/validator/dd_validator/model.py
+++ b/validator/dd_validator/model.py
@@ -27,6 +27,7 @@ class Level(enum.Enum):
 
     @property
     def order(self) -> int:
+        """Sort rank: lower is more severe (ERROR sorts first)."""
         return self.value
 
     def __str__(self) -> str:

--- a/validator/dd_validator/report.py
+++ b/validator/dd_validator/report.py
@@ -36,12 +36,15 @@ def render(findings: Sequence[Finding], fmt: str = "text", *, file: str = "") ->
 
 
 def _render_text(findings: Sequence[Finding], file: str) -> str:
-    prefix = f"{file}:" if file else ""
     lines = []
-    for f in findings:
-        loc = f"{prefix}{f.line}" if f.line is not None else (file or "<file>")
-        line = f"{loc}: {f.level} {f.check} — {f.message}"
-        lines.append(line)
+    for finding in findings:
+        # "file.csv:12" for a row finding; just the file name for a
+        # whole-file finding (e.g. a missing header) with no line number.
+        if finding.line is not None:
+            location = f"{file}:{finding.line}" if file else str(finding.line)
+        else:
+            location = file or "<file>"
+        lines.append(f"{location}: {finding.level} {finding.check} — {finding.message}")
     return "\n".join(lines) + ("\n" if lines else "")
 
 
@@ -49,15 +52,15 @@ def _render_table(findings: Sequence[Finding], file: str, *, delimiter: str) -> 
     buffer = io.StringIO()
     writer = csv.writer(buffer, delimiter=delimiter, lineterminator="\n")
     writer.writerow(_TABLE_HEADER)
-    for f in findings:
+    for finding in findings:
         writer.writerow(
             [
                 file,
-                "" if f.line is None else f.line,
-                f.level.name,
-                f.check,
-                f.message,
-                f.value or "",
+                "" if finding.line is None else finding.line,
+                finding.level.name,
+                finding.check,
+                finding.message,
+                finding.value or "",
             ]
         )
     return buffer.getvalue()
@@ -68,14 +71,14 @@ def _render_json(findings: Sequence[Finding], file: str) -> str:
         "file": file,
         "findings": [
             {
-                "level": f.level.name,
-                "check": f.check,
-                "message": f.message,
-                "line": f.line,
-                "column": f.column,
-                "value": f.value,
+                "level": finding.level.name,
+                "check": finding.check,
+                "message": finding.message,
+                "line": finding.line,
+                "column": finding.column,
+                "value": finding.value,
             }
-            for f in findings
+            for finding in findings
         ],
     }
     return json.dumps(payload, indent=2) + "\n"

--- a/validator/dd_validator/report.py
+++ b/validator/dd_validator/report.py
@@ -1,0 +1,81 @@
+"""Render findings in one of several formats.
+
+``text`` is the human-friendly default. ``csv`` and ``tsv`` are tabular (the
+header and data columns agree — a single ``File`` column, unlike the reference
+validator's writer which emitted a header column with no data). ``json`` is the
+machine-readable path, consistent with the other tools in this repository.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from collections.abc import Sequence
+
+from .model import Finding
+
+FORMATS = ("text", "csv", "tsv", "json")
+
+_TABLE_HEADER = ("File", "Row", "Level", "Check", "Message", "Value")
+
+
+def render(findings: Sequence[Finding], fmt: str = "text", *, file: str = "") -> str:
+    """Render ``findings`` as ``fmt`` (one of :data:`FORMATS`).
+
+    ``file`` names the source, used in the ``text`` prefix and the ``File``
+    table column.
+    """
+    if fmt == "text":
+        return _render_text(findings, file)
+    if fmt in ("csv", "tsv"):
+        return _render_table(findings, file, delimiter="\t" if fmt == "tsv" else ",")
+    if fmt == "json":
+        return _render_json(findings, file)
+    raise ValueError(f"unknown report format: {fmt!r}")
+
+
+def _render_text(findings: Sequence[Finding], file: str) -> str:
+    prefix = f"{file}:" if file else ""
+    lines = []
+    for f in findings:
+        loc = f"{prefix}{f.line}" if f.line is not None else (file or "<file>")
+        line = f"{loc}: {f.level} {f.check} — {f.message}"
+        lines.append(line)
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def _render_table(findings: Sequence[Finding], file: str, *, delimiter: str) -> str:
+    buffer = io.StringIO()
+    writer = csv.writer(buffer, delimiter=delimiter, lineterminator="\n")
+    writer.writerow(_TABLE_HEADER)
+    for f in findings:
+        writer.writerow(
+            [
+                file,
+                "" if f.line is None else f.line,
+                f.level.name,
+                f.check,
+                f.message,
+                f.value or "",
+            ]
+        )
+    return buffer.getvalue()
+
+
+def _render_json(findings: Sequence[Finding], file: str) -> str:
+    payload = {
+        "file": file,
+        "findings": [
+            {
+                "level": f.level.name,
+                "check": f.check,
+                "message": f.message,
+                "line": f.line,
+                "column": f.column,
+                "value": f.value,
+            }
+            for f in findings
+        ],
+    }
+    return json.dumps(payload, indent=2) + "\n"

--- a/validator/dd_validator/rows.py
+++ b/validator/dd_validator/rows.py
@@ -1,0 +1,72 @@
+"""Read a data dictionary CSV into raw rows, without validating.
+
+The converter's :func:`dd_converter.read_data_dictionary` is *fail-fast*: it
+raises on the first duplicate Id, blank required cell, or bad header. A
+validator must instead collect *every* problem, so it cannot use that reader as
+its front door. This module reads the CSV at the same raw level the converter's
+reader does (stdlib :mod:`csv`, ``utf-8-sig``, RFC 4180), but performs no
+validation — every data problem is left for the checks to report.
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TextIO
+
+
+@dataclass(frozen=True)
+class RawRow:
+    """One data record, exactly as read (no validation).
+
+    ``cells`` maps column header -> raw cell string (empty string for a blank or
+    absent cell). ``line`` is the 1-based line number in the source file.
+    """
+
+    cells: dict[str, str]
+    line: int
+
+    def get(self, column: str) -> str:
+        """Return the raw cell for ``column`` (empty string if absent/blank)."""
+        return self.cells.get(column, "")
+
+
+def read_rows(source: str | Path | TextIO) -> tuple[list[str], list[RawRow]]:
+    """Read a CSV into ``(header, rows)`` without raising on data problems.
+
+    Returns the header as a list of (stripped) column names and the data rows in
+    file order. An empty file yields ``([], [])``. Wholly blank lines are
+    skipped, matching the converter's reader.
+    """
+    if isinstance(source, (str, Path)):
+        with open(source, encoding="utf-8-sig", newline="") as handle:
+            return _read(handle)
+    return _read(source)
+
+
+def _read(handle: TextIO) -> tuple[list[str], list[RawRow]]:
+    reader = csv.reader(handle)  # RFC 4180 defaults: comma, double-quote
+    try:
+        raw_header = next(reader)
+    except StopIteration:
+        return [], []
+
+    # Strip a UTF-8 BOM from the first header cell if a caller-supplied stream
+    # carried one (a path opened above uses utf-8-sig, which removes it).
+    if raw_header and raw_header[0].startswith("﻿"):
+        raw_header[0] = raw_header[0].lstrip("﻿")
+    header = [h.strip() for h in raw_header]
+
+    rows: list[RawRow] = []
+    for offset, raw_cells in enumerate(reader):
+        line = offset + 2  # +1 for header, +1 for 1-based
+        if not any(cell.strip() for cell in raw_cells):
+            continue  # skip wholly blank lines
+        cells = {
+            header[i]: (raw_cells[i] if i < len(raw_cells) else "")
+            for i in range(len(header))
+        }
+        rows.append(RawRow(cells=cells, line=line))
+
+    return header, rows

--- a/validator/dd_validator/validate.py
+++ b/validator/dd_validator/validate.py
@@ -1,0 +1,50 @@
+"""Run every check against a data dictionary and collect all findings."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TextIO
+
+from . import checks
+from .model import Finding, Level
+from .rows import RawRow, read_rows
+
+
+def validate(
+    source: str | Path | TextIO,
+    *,
+    check_duplicate_ids: bool = True,
+) -> list[Finding]:
+    """Validate a data dictionary CSV and return all findings, sorted.
+
+    ``source`` may be a path or an open text file object. Findings are ordered
+    by source line, then severity, then check name. Set ``check_duplicate_ids``
+    to ``False`` to match the reference validator, which performs no cross-row
+    checks.
+    """
+    header, rows = read_rows(source)
+    findings = list(_run(header, rows, check_duplicate_ids=check_duplicate_ids))
+    findings.sort(key=lambda f: f.sort_key)
+    return findings
+
+
+def _run(
+    header: list[str], rows: list[RawRow], *, check_duplicate_ids: bool
+) -> list[Finding]:
+    if not header:
+        return [Finding(Level.ERROR, "empty-file", "the file has no header record")]
+
+    columns_present = set(header)
+    findings: list[Finding] = []
+    findings.extend(checks.check_required_headers(header))
+    findings.extend(checks.check_id(rows, columns_present))
+    findings.extend(checks.check_label(rows, columns_present))
+    findings.extend(checks.check_datatype(rows, columns_present))
+    findings.extend(checks.check_cardinality(rows, columns_present))
+    findings.extend(checks.check_pattern(rows, columns_present))
+    findings.extend(checks.check_enumeration(rows, columns_present))
+    findings.extend(checks.check_missing_value_codes(rows, columns_present))
+    findings.extend(checks.check_see_also(rows, columns_present))
+    if check_duplicate_ids:
+        findings.extend(checks.check_duplicate_ids(rows, columns_present))
+    return findings

--- a/validator/dd_validator/validate.py
+++ b/validator/dd_validator/validate.py
@@ -23,14 +23,19 @@ def validate(
     checks.
     """
     header, rows = read_rows(source)
-    findings = list(_run(header, rows, check_duplicate_ids=check_duplicate_ids))
-    findings.sort(key=lambda f: f.sort_key)
+    findings = _run_all_checks(header, rows, check_duplicate_ids=check_duplicate_ids)
+    findings.sort(key=lambda finding: finding.sort_key)
     return findings
 
 
-def _run(
+def _run_all_checks(
     header: list[str], rows: list[RawRow], *, check_duplicate_ids: bool
 ) -> list[Finding]:
+    """Run every check and return the unsorted findings.
+
+    A file with no header record at all cannot be checked further, so that is
+    the single finding it produces.
+    """
     if not header:
         return [Finding(Level.ERROR, "empty-file", "the file has no header record")]
 

--- a/validator/pyproject.toml
+++ b/validator/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dd-validate"
+version = "0.0.1"
+description = "Validate a data dictionary CSV against the specification and report violations"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "BSD-2-Clause" }
+dependencies = [
+    # The data-dictionary reader and per-cell parsers (datatype resolution,
+    # enumeration / missing-value-codes grammars) are reused from the sibling
+    # converter. It is not on PyPI, so depend on it directly from this
+    # repository; this lets `pip/pipx install <validator>` pull it in one step.
+    "dd-converter @ git+https://github.com/bmir-radx/radx-data-dictionary-specification.git#subdirectory=converter",
+]
+
+[project.optional-dependencies]
+test = ["pytest>=7"]
+
+[project.scripts]
+dd-validate = "dd_validator.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["dd_validator*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/validator/tests/test_checks.py
+++ b/validator/tests/test_checks.py
@@ -1,0 +1,171 @@
+"""Tests for the individual checks."""
+
+from dd_validator.checks import (
+    check_cardinality,
+    check_datatype,
+    check_duplicate_ids,
+    check_enumeration,
+    check_id,
+    check_label,
+    check_missing_value_codes,
+    check_pattern,
+    check_required_headers,
+    check_see_also,
+)
+from dd_validator.model import Level
+from dd_validator.rows import RawRow
+
+
+def _rows(*records):
+    """Build RawRows from (line, {col: val}) tuples."""
+    return [RawRow(cells=cells, line=line) for line, cells in records]
+
+
+# --- required headers ------------------------------------------------------
+
+def test_required_headers_all_present():
+    assert list(check_required_headers(["Id", "Label", "Datatype"])) == []
+
+
+def test_required_headers_missing_reported():
+    findings = list(check_required_headers(["Id", "Datatype"]))
+    assert [f.column for f in findings] == ["Label"]
+    assert findings[0].level is Level.ERROR
+
+
+def test_required_headers_suggests_rename_on_case_mismatch():
+    (finding,) = list(check_required_headers(["id", "Label", "Datatype"]))
+    assert finding.column == "Id"
+    assert "did you mean" in finding.message and "'id'" in finding.message
+
+
+# --- id --------------------------------------------------------------------
+
+def test_id_missing():
+    (f,) = list(check_id(_rows((2, {"Id": ""})), {"Id"}))
+    assert f.check == "id-missing" and f.level is Level.ERROR
+
+
+def test_id_leading_space_yields_error_and_info():
+    findings = list(check_id(_rows((2, {"Id": " age"})), {"Id"}))
+    checks = {f.check: f.level for f in findings}
+    assert checks == {"id-leading-whitespace": Level.ERROR, "id-whitespace": Level.INFO}
+
+
+def test_id_interior_space_is_info_only():
+    findings = list(check_id(_rows((2, {"Id": "a b"})), {"Id"}))
+    assert [f.check for f in findings] == ["id-whitespace"]
+    assert findings[0].level is Level.INFO
+
+
+def test_id_absent_column_is_silent():
+    assert list(check_id(_rows((2, {"Label": "x"})), {"Label"})) == []
+
+
+# --- label -----------------------------------------------------------------
+
+def test_label_missing_is_warning():
+    (f,) = list(check_label(_rows((2, {"Label": ""})), {"Label"}))
+    assert f.level is Level.WARNING and f.check == "label-missing"
+
+
+def test_label_present_is_silent():
+    assert list(check_label(_rows((2, {"Label": "Age"})), {"Label"})) == []
+
+
+# --- datatype --------------------------------------------------------------
+
+def test_datatype_missing():
+    (f,) = list(check_datatype(_rows((2, {"Datatype": ""})), {"Datatype"}))
+    assert f.check == "datatype-missing"
+
+
+def test_datatype_known_is_silent():
+    assert list(check_datatype(_rows((2, {"Datatype": "integer"})), {"Datatype"})) == []
+
+
+def test_datatype_unknown_with_case_suggestion():
+    (f,) = list(check_datatype(_rows((2, {"Datatype": "Integer"})), {"Datatype"}))
+    assert f.check == "unknown-datatype"
+    assert "'integer'" in f.message
+
+
+def test_datatype_unknown_with_fixmap_suggestion():
+    (f,) = list(check_datatype(_rows((2, {"Datatype": "text"})), {"Datatype"}))
+    assert "'string'" in f.message
+
+
+def test_datatype_unknown_without_suggestion():
+    (f,) = list(check_datatype(_rows((2, {"Datatype": "zorb"})), {"Datatype"}))
+    assert "did you mean" not in f.message
+
+
+# --- cardinality -----------------------------------------------------------
+
+def test_cardinality_valid():
+    rows = _rows((2, {"Cardinality": "single"}), (3, {"Cardinality": "multiple"}))
+    assert list(check_cardinality(rows, {"Cardinality"})) == []
+
+
+def test_cardinality_blank_is_silent():
+    assert list(check_cardinality(_rows((2, {"Cardinality": ""})), {"Cardinality"})) == []
+
+
+def test_cardinality_invalid():
+    (f,) = list(check_cardinality(_rows((2, {"Cardinality": "many"})), {"Cardinality"}))
+    assert f.check == "invalid-cardinality"
+
+
+# --- pattern ---------------------------------------------------------------
+
+def test_pattern_valid():
+    assert list(check_pattern(_rows((2, {"Pattern": "^[0-9]+$"})), {"Pattern"})) == []
+
+
+def test_pattern_malformed():
+    (f,) = list(check_pattern(_rows((2, {"Pattern": "[a-z"})), {"Pattern"}))
+    assert f.check == "malformed-pattern"
+
+
+# --- enumeration / missing value codes -------------------------------------
+
+def test_enumeration_valid():
+    rows = _rows((2, {"Enumeration": '"0"=[No] | "1"=[Yes]'}))
+    assert list(check_enumeration(rows, {"Enumeration"})) == []
+
+
+def test_enumeration_malformed():
+    (f,) = list(check_enumeration(_rows((2, {"Enumeration": '"0"=[No] | "1"'})), {"Enumeration"}))
+    assert f.check == "malformed-enumeration"
+
+
+def test_missing_value_codes_malformed():
+    rows = _rows((2, {"MissingValueCodes": "garbage"}))
+    (f,) = list(check_missing_value_codes(rows, {"MissingValueCodes"}))
+    assert f.check == "malformed-missing-value-codes"
+
+
+# --- see also --------------------------------------------------------------
+
+def test_see_also_absolute_is_silent():
+    rows = _rows((2, {"SeeAlso": "https://example.org/x"}))
+    assert list(check_see_also(rows, {"SeeAlso"})) == []
+
+
+def test_see_also_relative_is_error():
+    (f,) = list(check_see_also(_rows((2, {"SeeAlso": "not-a-url"})), {"SeeAlso"}))
+    assert f.check == "malformed-see-also"
+
+
+# --- duplicate ids ---------------------------------------------------------
+
+def test_duplicate_ids():
+    rows = _rows((2, {"Id": "a"}), (3, {"Id": "b"}), (4, {"Id": "a"}))
+    findings = list(check_duplicate_ids(rows, {"Id"}))
+    assert [f.line for f in findings] == [4]
+    assert "first seen on line 2" in findings[0].message
+
+
+def test_no_duplicate_ids():
+    rows = _rows((2, {"Id": "a"}), (3, {"Id": "b"}))
+    assert list(check_duplicate_ids(rows, {"Id"})) == []

--- a/validator/tests/test_cli.py
+++ b/validator/tests/test_cli.py
@@ -1,0 +1,69 @@
+"""Tests for the command-line interface."""
+
+import json
+
+from dd_validator.cli import main
+
+CLEAN = "Id,Label,Datatype\nage,Age,integer\n"
+DIRTY = "Id,Label,Datatype\nage,Age,Nope\n"  # unknown datatype -> ERROR
+
+
+def test_clean_exits_zero(tmp_path, capsys):
+    p = tmp_path / "clean.csv"
+    p.write_text(CLEAN)
+    assert main([str(p)]) == 0
+    assert "0 error(s)" in capsys.readouterr().err
+
+
+def test_errors_exit_one(tmp_path, capsys):
+    p = tmp_path / "dirty.csv"
+    p.write_text(DIRTY)
+    assert main([str(p)]) == 1
+    assert "unknown-datatype" in capsys.readouterr().out
+
+
+def test_exit_zero_flag_overrides(tmp_path):
+    p = tmp_path / "dirty.csv"
+    p.write_text(DIRTY)
+    assert main([str(p), "--exit-zero"]) == 0
+
+
+def test_missing_input_exits_two(capsys):
+    assert main(["/no/such/file.csv"]) == 2
+    assert "not found" in capsys.readouterr().err
+
+
+def test_json_output_to_file(tmp_path):
+    p = tmp_path / "dirty.csv"
+    p.write_text(DIRTY)
+    out = tmp_path / "report.json"
+    main([str(p), "-o", str(out), "-f", "json"])
+    payload = json.loads(out.read_text())
+    assert payload["findings"][0]["check"] == "unknown-datatype"
+
+
+def test_levels_filter(tmp_path, capsys):
+    # A row with only a label warning; filtering to ERROR should hide it.
+    p = tmp_path / "warn.csv"
+    p.write_text("Id,Label,Datatype\nage,,integer\n")
+    assert main([str(p), "--levels", "ERROR"]) == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_no_duplicate_check_flag(tmp_path, capsys):
+    p = tmp_path / "dup.csv"
+    p.write_text("Id,Label,Datatype\na,A,integer\na,A2,integer\n")
+    assert main([str(p), "--no-duplicate-check"]) == 0
+    out = capsys.readouterr().out
+    assert "duplicate-id" not in out
+
+
+def test_directory_input(tmp_path, capsys):
+    (tmp_path / "a.csv").write_text(CLEAN)
+    (tmp_path / "b.csv").write_text(DIRTY)
+    rc = main([str(tmp_path), "-f", "csv"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    # One header row shared across both files' sections.
+    assert out.count("File,Row,Level,Check,Message,Value") == 1
+    assert "unknown-datatype" in out

--- a/validator/tests/test_report.py
+++ b/validator/tests/test_report.py
@@ -1,0 +1,53 @@
+"""Tests for report rendering."""
+
+import json
+
+from dd_validator.model import Finding, Level
+from dd_validator.report import render
+
+FINDINGS = [
+    Finding(Level.ERROR, "unknown-datatype", "'Nope' is not a known datatype name",
+            line=3, column="Datatype", value="Nope"),
+    Finding(Level.WARNING, "label-missing", "Label is missing", line=2, column="Label"),
+]
+
+
+def test_text_format():
+    out = render(FINDINGS, "text", file="d.csv")
+    assert "d.csv:3: ERROR unknown-datatype — 'Nope' is not a known datatype name" in out
+    assert "d.csv:2: WARNING label-missing" in out
+
+
+def test_text_format_empty():
+    assert render([], "text", file="d.csv") == ""
+
+
+def test_csv_header_and_rows_agree():
+    out = render(FINDINGS, "csv", file="d.csv")
+    lines = out.strip().splitlines()
+    header = lines[0].split(",")
+    first_row = lines[1].split(",")
+    assert header == ["File", "Row", "Level", "Check", "Message", "Value"]
+    assert len(first_row) == len(header)  # no phantom column (unlike the Java writer)
+
+
+def test_tsv_is_tab_delimited():
+    out = render(FINDINGS, "tsv", file="d.csv")
+    assert "\t" in out.splitlines()[0]
+
+
+def test_json_format():
+    out = render(FINDINGS, "json", file="d.csv")
+    payload = json.loads(out)
+    assert payload["file"] == "d.csv"
+    assert payload["findings"][0]["check"] == "unknown-datatype"
+    assert payload["findings"][0]["line"] == 3
+
+
+def test_unknown_format_raises():
+    try:
+        render(FINDINGS, "xml")
+    except ValueError as exc:
+        assert "xml" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")

--- a/validator/tests/test_validate.py
+++ b/validator/tests/test_validate.py
@@ -1,0 +1,62 @@
+"""Tests for the orchestrator and the raw-row reader."""
+
+import io
+
+from dd_validator import validate
+from dd_validator.model import Level
+from dd_validator.rows import read_rows
+
+CLEAN = "Id,Label,Datatype\nage,Age,integer\nweight,Weight,decimal\n"
+
+
+def _validate(text, **kwargs):
+    return validate(io.StringIO(text), **kwargs)
+
+
+def test_clean_dictionary_has_no_findings():
+    assert _validate(CLEAN) == []
+
+
+def test_empty_file_reports_empty_file():
+    (f,) = _validate("")
+    assert f.check == "empty-file" and f.level is Level.ERROR
+
+
+def test_findings_sorted_by_line_then_severity():
+    text = (
+        "Id,Label,Datatype\n"
+        "a,,integer\n"        # line 2: label warning
+        " b,B,Nope\n"          # line 3: id error + info, datatype error
+    )
+    findings = _validate(text)
+    # sorted: line 2 first, then line 3 errors before info
+    assert findings[0].line == 2
+    lines_levels = [(f.line, f.level) for f in findings]
+    assert lines_levels == sorted(lines_levels, key=lambda x: (x[0], x[1].order))
+
+
+def test_duplicate_check_toggle():
+    text = CLEAN + "age,Age2,integer\n"
+    with_dup = [f for f in _validate(text) if f.check == "duplicate-id"]
+    without = [f for f in _validate(text, check_duplicate_ids=False) if f.check == "duplicate-id"]
+    assert len(with_dup) == 1 and without == []
+
+
+def test_missing_required_header():
+    text = "Id,Datatype\na,integer\n"
+    checks = {f.check for f in _validate(text)}
+    assert "required-header" in checks
+
+
+def test_optional_column_absent_is_not_flagged():
+    # No Cardinality/Pattern/SeeAlso columns: their checks must stay silent.
+    findings = _validate(CLEAN)
+    assert findings == []
+
+
+def test_read_rows_skips_blank_lines_and_strips_bom():
+    text = "﻿Id,Label,Datatype\nage,Age,integer\n\n\nweight,Weight,decimal\n"
+    header, rows = read_rows(io.StringIO(text))
+    assert header == ["Id", "Label", "Datatype"]
+    assert [r.get("Id") for r in rows] == ["age", "weight"]
+    assert [r.line for r in rows] == [2, 5]  # line numbers reflect the blank gaps


### PR DESCRIPTION
Adds the third tool in this repo: a **validator** (`validator/`, package `dd_validator`, command `dd-validate`), sibling to the converter and printer. It checks a data dictionary CSV against the specification and **reports every violation it finds** — it does not transform the dictionary.

Ported from the Java validator ([bmir-radx/radx-data-dictionary-validator](https://github.com/bmir-radx/radx-data-dictionary-validator)), generic/de-branded from the start, following the conventions established by the converter and printer. Design record: [`validator/VALIDATOR_PLAN.md`](validator/VALIDATOR_PLAN.md).

## What it checks

| Check | Severity |
| --- | --- |
| Required headers (`Id`/`Label`/`Datatype`) present | ERROR |
| Id present / leading-whitespace / contains-whitespace | ERROR / ERROR / INFO |
| Label present | WARNING |
| Datatype present / known (with "did you mean?" suggestions) | ERROR |
| Cardinality is `single`/`multiple` | ERROR |
| Pattern compiles as a regex | ERROR |
| Enumeration / MissingValueCodes parse | ERROR |
| SeeAlso is an absolute URL | ERROR |
| Duplicate Ids | ERROR |

The datatype names and the enumeration / missing-value-codes grammars are **reused from `dd_converter`**, so the validator stays in lockstep with the converter and the spec. A check whose column is absent from the header does nothing (a missing *optional* column is not a problem) — matching the reference validator.

## Design decisions (departures from the Java original, all confirmed)

- **Collect-all, not fail-fast.** `dd_converter.read_data_dictionary` raises on the first problem; the validator reads the CSV at the raw level (same stdlib `csv` shape) and collects *all* findings.
- **Duplicate-Id check added** (ERROR). Not in the Java tool, but the converter refuses duplicate Ids, so the validator agrees with it. Verified against `rad.dd.csv`: both the converter and the validator flag the same duplicates (the committed `rad.yaml` was generated with `--allow-duplicates`). `--no-duplicate-check` restores the reference behavior.
- **Exit code gates on errors** (1 on any ERROR, 2 on usage error, 0 otherwise) so it can gate CI. The Java tool always returned 0; `--exit-zero` restores that.
- **JSON output added** alongside csv/tsv (the machine path, consistent with the other tools); **text is the default** (human-first, like the printer). The csv/tsv table's header and data columns agree (the Java writer emitted a header column with no data field).
- **Single canonical column vocabulary** from `dd_converter.KNOWN_COLUMNS`/`REQUIRED_COLUMNS` — resolves the Java source's header-vocabulary split.

## Verification

- 47 tests pass (`pytest validator`).
- ruff-clean (`F,E,W,B,C4,UP,SIM` @ 100 cols).
- Ran against both cleared example dictionaries: `gcb.dd.csv` is clean; `rad.dd.csv` surfaces genuine duplicate Ids (consistent with the converter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)