### PR TITLE
Add a REDCap data dictionary converter (redcap-to-dd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ renderings and tooling built on top of it.
 | [`printer/`](printer/) | A Python tool that renders a data dictionary to a human-readable HTML page (or JSON). |
 | [`validator/`](validator/) | A Python tool that checks a data dictionary against the specification and reports violations. |
 | [`api/`](api/) | A high-level Python API: load a data dictionary and work with typed, parsed objects. |
+| [`redcap/`](redcap/) | A Python tool that converts a REDCap data dictionary export into this format. |
 | [`linkml/`](linkml/) | Hand-written [LinkML](https://linkml.io) renderings of the specification. |
 
 ## Converter
@@ -117,6 +118,21 @@ for choice in age.enumeration:
 See the [API README](api/README.md) for the conventions and the full surface,
 and the [Cookbook](api/COOKBOOK.md) for ten pasteable recipes with their
 output.
+
+## REDCap converter
+
+[`redcap/`](redcap/) converts a **REDCap data dictionary export** into this
+specification's format — field names, labels, sections, choices, datatypes,
+and generated prose descriptions (including plain-English explanations of
+REDCap branching logic). The result works with every tool above.
+
+```sh
+pipx install "git+https://github.com/bmir-radx/radx-data-dictionary-specification.git#subdirectory=redcap"
+
+redcap-to-dd redcap_export.csv -o my_dictionary.csv
+```
+
+See the [REDCap README](redcap/README.md) for the full mapping.
 
 ## Hand-written LinkML schemas
 

--- a/redcap/CONVERSION.md
+++ b/redcap/CONVERSION.md
@@ -1,0 +1,171 @@
+# The Conversion Algorithm
+
+How `redcap-to-dd` turns a REDCap data dictionary export into a data
+dictionary in [this specification's format](../radx-data-dictionary-specification.md).
+This is the authoritative description of the strategy; the code in
+`dd_redcap/` follows it module by module.
+
+## Pipeline
+
+1. **Read the sheet** (`headers.py`). The CSV is parsed (UTF-8, BOM
+   tolerated) and its columns are recognised by name — case-insensitively,
+   with the common short forms accepted (`Variable / Field Name` /
+   `Variable` / `Field Name`; `Field Label` / `Label` / `Prompt`;
+   `Field Type` / `Type`; `Choices, Calculations, OR Slider Labels` /
+   `Choices`; …). A file with no recognisable Variable column is rejected
+   (`ConversionError`) — it is not a REDCap dictionary. Any *other* missing
+   column is fine: its cells simply read as blank, because real exports are
+   often trimmed by hand.
+2. **Convert row by row** (`convert.py`). Each REDCap row becomes one
+   `dd_api.DataElement`, except:
+   - rows whose Field Type is `descriptive` — display text on the form, not
+     a data field — are skipped;
+   - rows with a blank Variable cell are skipped with a logged warning.
+3. **Assemble and write.** The elements form a `dd_api.DataDictionary`
+   (duplicate Variable names therefore fail loudly), and the output CSV is
+   produced by `DataDictionary.to_csv()` — so it is canonical by
+   construction and round-trips through every other tool in this repo.
+
+## Per-column strategy
+
+| Output column | Strategy |
+| --- | --- |
+| `Id` | The Variable / Field Name cell, verbatim. |
+| `Label` | The Field Label; a non-blank Field Note is appended in parentheses — `Packs per day` + note `per day` → `Packs per day (per day)`. |
+| `Section` | The Section Header, **carried forward**: REDCap writes a section name only on the first row of a section, so a blank cell means "same section as the previous row". |
+| `Cardinality` | `multiple` when Field Type is `checkbox` (each choice is its own datafile column holding 0/1); otherwise `single` (radio, dropdown, text, …). |
+| `Enumeration` | The Choices cell, parsed per the grammar below, one `"value"=[label]` pair per choice, order preserved. |
+| `Datatype` | The decision tree below. |
+| `Description` | Generated prose — see below. |
+| `Notes` | The Field Annotation, split on `\|`; `@NONEOFTHEABOVE` actions are removed (they are *explained* in the description instead); the rest joined as paragraphs. |
+| `Provenance` | The `--provenance` flag (or `provenance=` argument), the same for every element. |
+| `Aliases`, `Terms`, `Pattern`, `Unit`, `MissingValueCodes`, `Examples`, `SeeAlso` | Left empty — REDCap has no counterpart. (Text Validation Min/Max are currently not carried; a future version could render them into `Pattern` or the description.) |
+
+## How Field Type drives the conversion
+
+Field Type is the pivot of the whole conversion: it decides whether a row is
+a data field at all, how many values a datafile cell holds, and where the
+datatype comes from. Type by type:
+
+| Field Type | Row kept? | Cardinality | Enumeration | Datatype comes from |
+| --- | --- | --- | --- | --- |
+| `descriptive` | **No** — display text on the form, not a field. | — | — | — |
+| `radio` | Yes | `single` | from Choices | the choice values (`integer` if the first is all digits, else `string`) |
+| `dropdown` | Yes | `single` | from Choices | the choice values, as above |
+| `checkbox` | Yes | **`multiple`** — each choice is its own 0/1 column in the datafile | from Choices | the choice values, as above |
+| `text` | Yes | `single` | none | the Text Validation Type, via the datatype table below (plus the `MM/DD/YYYY` field-note idiom) |
+| `notes` | Yes | `single` | none | no validation → `string` |
+| `calc` | Yes | `single` | none | no validation → `string` (the calculation expression is not interpreted) |
+| `yesno`, `truefalse` | Yes | `single` | **none** — REDCap implies 0/1 choices without a Choices cell, and the converter does not synthesise them (a known gap; see below) | `string` |
+| `slider`, `file`, anything else | Yes | `single` | none (unless a Choices cell is present) | validation if present, else `string` |
+
+Three things to notice about the interplay:
+
+- **Choices beat validation.** When a row has a Choices cell, the datatype
+  is derived from the choice *values*, and any Text Validation Type is
+  ignored — an enumerated field's type is the type of its codes.
+- **Cardinality is purely a Field Type fact.** Only `checkbox` produces
+  `multiple`; a radio and a dropdown enumerate the same way but stay
+  `single`. Nothing else (choices, validation) affects cardinality.
+- **Only `descriptive` removes a row.** Every other type converts —
+  unrecognised types deliberately degrade to a `single` `string` field
+  rather than being dropped, so no data element silently disappears.
+
+Known gap, inherited from the Java original: `yesno` / `truefalse` fields
+carry their 0/1 (true/false) choice lists implicitly, with no Choices cell,
+so they currently convert as plain `string` fields with no enumeration. A
+future version could synthesise `"0"=[No] | "1"=[Yes]` (and
+`"0"=[False] | "1"=[True]`) for them.
+
+## The choices grammar
+
+A Choices cell lists `value, label` pairs separated by `|` — or by `;` in
+older exports, used only when the cell contains no pipe at all:
+
+```
+1, Yes | 2, No | 3, Maybe
+```
+
+Only the **first** comma of each item splits value from label, so labels
+keep their own commas (`1, Less than $15,000`). An item with no comma is its
+own label. Values and labels are trimmed; order is preserved.
+
+## The datatype decision tree
+
+1. **The field has choices** → the datatype of its *values*: `integer` when
+   the first choice value is all digits, else `string`.
+2. **No choices, blank validation** → `string`.
+3. **Validation `text` with Field Note `MM/DD/YYYY`** → `date_mdy` (a REDCap
+   idiom for US-format dates).
+4. **Otherwise** the validation name is looked up in one explicit table
+   (`datatypes.py`): `integer` → `integer`; `number`, `number_1dp..4dp` →
+   `decimal`; `date_ymd` → `date` (Y-M-D is the XSD lexical form);
+   `date_mdy` / `datetime_seconds_mdy` → `date_mdy`; `date_dmy` /
+   `datetime_seconds_dmy` → `date_dmy`; `datetime_seconds_ymd` → `dateTime`;
+   `time`, `time_hh_mm_ss` → `time`. Anything else (emails, phone numbers,
+   zip codes, institutional id formats, partial dates like `date_my`) →
+   `string` — never silently something stricter than the data warrants.
+
+A test asserts every name the table maps to is a valid spec datatype.
+
+## The generated description
+
+Up to three paragraphs, blank ones omitted:
+
+1. **The prompt** — `` The `{id}` variable records response to the prompt,
+   _"{label}"_. ``
+2. **The permissible values** (enumerated fields only) — "Values for this
+   variable are {datatype}s that are restricted to the list of {n}
+   permissible {datatype} values." If the Field Annotation carries a
+   `@NONEOFTHEABOVE = '98,99'` action, a sentence names those values as
+   mutually exclusive with all others.
+3. **The branching logic.** A REDCap field with branching logic is only
+   shown — and so only filled in — when a condition on other fields holds;
+   datafile readers otherwise see it as mysteriously blank. Three condition
+   shapes are recognised per clause (clauses split on ` and `):
+   `[field(3)] = '1'` (one checkbox choice ticked), `[field] = '2'` (a value
+   test), and `[field] <> ''` (non-blank). Each becomes "the value of
+   `field` is `choice`", and the *meaning* of the choice is resolved by
+   looking up the referenced field's own choice list — so `[smoker] = '1'`
+   renders with `_"Yes"_`. A clause matching none of the shapes is quoted
+   verbatim: "the condition `[bmi] > 30` evaluates to true".
+
+## Worked example
+
+Input (two REDCap rows):
+
+```csv
+Variable / Field Name,Section Header,Field Type,Field Label,"Choices, Calculations, OR Slider Labels",Field Note,Text Validation Type OR Show Slider Number,Branching Logic (Show field only if...),Field Annotation
+smoker,Lifestyle,radio,Do you smoke?,"0, No | 1, Yes",,,,
+packs,,text,Packs per day,,per day,number,[smoker] = '1',@HIDDEN
+```
+
+The converted `packs` element (converted with `--provenance "Demo Study"`):
+
+| Column | Value |
+| --- | --- |
+| `Id` | `packs` |
+| `Label` | `Packs per day (per day)` |
+| `Section` | `Lifestyle` *(carried forward)* |
+| `Datatype` | `decimal` *(validation `number`)* |
+| `Cardinality` | `single` |
+| `Notes` | `@HIDDEN` |
+| `Provenance` | `Demo Study` |
+
+and its generated description:
+
+> The `packs` variable records response to the prompt, _"Packs per day (per
+> day)"_.
+>
+> This variable only records a non-blank value if the value of `smoker` is
+> `1`, _"Yes"_.
+
+(This example is real output — reproduced from a run of the converter.)
+
+## Departures from the Java original
+
+Recorded in [`REDCAP_PLAN.md`](REDCAP_PLAN.md): the datatype table implements
+the Java's evident intent rather than its dead-code accident; a grammar slip
+in the values sentence is fixed; output is the full canonical column set via
+`dd_api` (the Java omitted Aliases/Examples); rows with a blank Variable cell
+are skipped with a warning rather than producing an empty-id record.

--- a/redcap/README.md
+++ b/redcap/README.md
@@ -63,6 +63,12 @@ accepted (`Variable`, `Label`, `Type`, `Choices`, …), so lightly hand-edited
 exports convert too. A file with no recognisable `Variable / Field Name`
 column is rejected with a clear error.
 
+## How the conversion works
+
+The algorithm — including how REDCap's **Field Type** drives row filtering,
+cardinality, enumerations, and datatypes — is documented in
+[`CONVERSION.md`](CONVERSION.md), with a verified worked example.
+
 ## Development
 
 The design is recorded in [`REDCAP_PLAN.md`](REDCAP_PLAN.md). To run the

--- a/redcap/README.md
+++ b/redcap/README.md
@@ -1,0 +1,74 @@
+# REDCap Data Dictionary Converter
+
+`redcap-to-dd` converts a **REDCap data dictionary** — the CSV a REDCap
+project exports to describe its instruments — into a data dictionary in
+[this specification's format](../radx-data-dictionary-specification.md).
+Once converted, the whole toolkit applies: render it with the
+[printer](../printer/), check it with the [validator](../validator/), turn it
+into a LinkML schema with the [converter](../converter/), or work with it in
+Python through the [API](../api/).
+
+## What carries over
+
+| REDCap | Converted dictionary |
+| --- | --- |
+| Variable / Field Name | `Id` |
+| Field Label (+ Field Note in parens) | `Label` |
+| Section Header (carried forward over blank cells) | `Section` |
+| Field Type `checkbox` | `Cardinality` = `multiple` (else `single`) |
+| Choices (`1, Yes \| 2, No`) | `Enumeration` (`"1"=[Yes] \| "2"=[No]`) |
+| Text Validation Type (`integer`, `number_2dp`, `date_mdy`, …) | `Datatype` (`integer`, `decimal`, `date_mdy`, …; unrecognised formats become `string`) |
+| Field Annotation | `Notes` |
+| — (`--provenance` flag) | `Provenance` |
+
+Rows with Field Type `descriptive` are display text, not fields, and are
+skipped. A generated `Description` explains each field in prose: the prompt,
+how many permissible values it has (and which are mutually exclusive, from
+`@NONEOFTHEABOVE` annotations), and its **branching logic** — a REDCap
+condition like `[smoker] = '1'` becomes *"This variable only records a
+non-blank value if the value of `smoker` is `1`, \_"Yes"\_."*, with the
+choice label looked up from the referenced field.
+
+## Install
+
+```
+pipx install "git+https://github.com/bmir-radx/radx-data-dictionary-specification.git#subdirectory=redcap"
+```
+
+(Or `pip` into an existing environment. Pulls in the sibling `dd-api`
+package, which the converter builds its output on.)
+
+## Use it
+
+```
+# REDCap export in, data dictionary CSV out
+redcap-to-dd redcap_export.csv -o my_dictionary.csv --provenance "My Study"
+
+# ...or to stdout
+redcap-to-dd redcap_export.csv | less
+```
+
+From Python:
+
+```python
+from dd_redcap import convert_redcap
+
+dd = convert_redcap("redcap_export.csv", provenance="My Study")  # a dd_api DataDictionary
+dd.to_csv()      # the dictionary as CSV
+dd.to_linkml()   # or go straight to a LinkML schema
+```
+
+Column headers are matched case-insensitively and common short forms are
+accepted (`Variable`, `Label`, `Type`, `Choices`, …), so lightly hand-edited
+exports convert too. A file with no recognisable `Variable / Field Name`
+column is rejected with a clear error.
+
+## Development
+
+The design is recorded in [`REDCAP_PLAN.md`](REDCAP_PLAN.md). To run the
+tests:
+
+```
+pip install -e "./redcap[test]"
+pytest redcap
+```

--- a/redcap/REDCAP_PLAN.md
+++ b/redcap/REDCAP_PLAN.md
@@ -1,0 +1,92 @@
+# REDCap Converter — Plan
+
+A Python tool that converts a **REDCap data dictionary** (the CSV that REDCap
+exports) into a data dictionary in this repository's format. Ported from the
+Java `redcap-data-dictionary-converter`; fifth tool in the repo.
+
+Folder `redcap/`, package `dd_redcap`, command `redcap-to-dd`. Depends on
+**`dd-api`**: the converter builds `DataElement` objects and lets
+`DataDictionary.to_csv()` do the writing, so the output is canonical by
+construction (the Java version hand-printed CSV and omitted the Aliases and
+Examples columns; ours emits the full canonical column set).
+
+## What the Java converter does (behaviour to port)
+
+Per REDCap row, matched by header name (case-insensitive, with synonyms —
+e.g. `Variable / Field Name` / `Variable` / `Field Name`):
+
+- **Skip** rows whose Field Type is `descriptive` (display text, not a field).
+- **Id** ← Variable / Field Name (error if the column is absent).
+- **Label** ← Field Label, with a non-blank Field Note appended in parens:
+  `Age (in years)`.
+- **Section** ← Section Header, *carried forward* (REDCap does not fill
+  section headers down; blank means "same as the previous row").
+- **Cardinality** ← Field Type: `checkbox` → `multiple`; everything else
+  (radio, dropdown, text, …) → `single`.
+- **Enumeration** ← the Choices cell, parsed as `value, label` pairs
+  separated by `|` (or `;` when no pipe is present); the first comma splits
+  value from label, so labels keep their own commas (`1, Less than $15,000`);
+  an item with no comma is its own label.
+- **Datatype**: with choices → `integer` if the first choice value is all
+  digits, else `string`; without → mapped from the Text Validation Type
+  (see decision 1 below); special case: validation `text` with Field Note
+  `MM/DD/YYYY` → `date_mdy`; default `string`.
+- **Description** — generated prose:
+  `` The `{id}` variable records response to the prompt, _"{label}"_. `` plus,
+  for enumerated fields, a sentence about the number of permissible values
+  (and which values are mutually exclusive, per `@NONEOFTHEABOVE` field
+  annotations), plus a **branching-logic explanation**: expressions like
+  `[smoker] = '1'`, `[symptoms(3)] = '1'`, `[age] <> ''` (joined by `and`)
+  are rendered as `This variable only records a non-blank value if the value
+  of `smoker` is `1`, _"Yes"_.` — looking the choice label up from the row it
+  references. Unrecognised expressions fall back to quoting the condition.
+- **Notes** ← Field Annotation, split on `|`, with `@NONEOFTHEABOVE` actions
+  removed (they are explained in the description instead), rejoined as
+  paragraphs.
+- **Provenance** ← a caller-supplied string (CLI flag for us).
+- Terms, Pattern, Unit, MissingValueCodes, Aliases, Examples, SeeAlso: empty.
+
+## Decisions
+
+1. **Datatype mapping (depart from the Java accident).** The Java source
+   contains a rich validation-name table (`RedcapValidationType`: `number` →
+   decimal, `email` → string, …) that is **dead code** — the live path only
+   recognises the eight names `string, integer, decimal, date, date_mdy,
+   date_dmy, date_ymd, time` and silently strings everything else, and the two
+   disagree (`date_mdy` → `date` in the table, `date_mdy` live). The port
+   implements the evident *intent* as one explicit table mapping REDCap
+   validation names to **this spec's** datatype names:
+   `integer` → `integer`; `number`, `number_1dp..4dp` → `decimal`;
+   `date_ymd` → `date` (Y-M-D is the XSD lexical form); `date_mdy` /
+   `datetime_seconds_mdy` → `date_mdy`; `date_dmy` / `datetime_seconds_dmy` →
+   `date_dmy`; `datetime_seconds_ymd` → `dateTime`; `time`, `time_hh_mm_ss` →
+   `time`; everything else (email, phone, zipcode, ids, …) → `string`.
+   The table is data, easy to review and extend.
+2. **Description prose**: same templates as the Java, with its grammar slip
+   fixed ("are *that restricted* to" → "are restricted to").
+3. **Fail-fast, like the toolkit.** A REDCap sheet without a recognisable
+   Variable/Field-Name column raises a clear error. Everything else is
+   best-effort (REDCap exports are messy; missing optional columns are fine).
+4. **Round-trip check in tests**: the produced CSV must load with
+   `DataDictionary.load` (guaranteed by construction, but asserted anyway).
+
+## Layout
+
+```
+redcap/
+  REDCAP_PLAN.md  README.md  pyproject.toml   (deps: dd-api)
+  dd_redcap/
+    __init__.py    (exports: convert_redcap, ConversionError)
+    headers.py     (the REDCap column vocabulary + synonym lookup)
+    choices.py     (parse_choices: the "1, Yes | 2, No" notation)
+    datatypes.py   (validation-name -> spec datatype table)
+    branching.py   (branching-logic explanation)
+    convert.py     (row -> DataElement; convert_redcap -> DataDictionary)
+    cli.py         (redcap-to-dd INPUT [-o OUT] [--provenance TEXT])
+  tests/           (choices parser cases from the Java tests + converter,
+                    branching, datatype, CLI, round-trip tests)
+```
+
+Conventions as established: Python >=3.9, `from __future__ import
+annotations`, ruff (F,E,W,B,C4,UP,SIM,I @ 100), reStructuredText docstrings
+with doctest examples where they teach, pytest.

--- a/redcap/dd_redcap/__init__.py
+++ b/redcap/dd_redcap/__init__.py
@@ -1,0 +1,28 @@
+"""Convert a REDCap data dictionary into the specification's format.
+
+REDCap studies export their instrument definitions as a CSV of their own
+shape. This package reads that export and produces a
+:class:`~dd_api.DataDictionary` — so the result can be written as a
+data dictionary CSV, rendered with the printer, checked with the validator,
+or converted to LinkML, like any other dictionary::
+
+    from dd_redcap import convert_redcap
+
+    dd = convert_redcap("redcap_export.csv", provenance="My Study")
+    print(dd.to_csv())
+
+The conversion is described in ``REDCAP_PLAN.md``. What carries over: field
+names, labels (with field notes folded in), sections, choices (as
+enumerations), datatypes (from REDCap validation types), and generated prose
+descriptions that explain choice counts and branching logic in plain English.
+"""
+
+from .convert import convert_redcap
+from .headers import ConversionError, RedCapSheet, read_sheet
+
+__all__ = [
+    "convert_redcap",
+    "ConversionError",
+    "RedCapSheet",
+    "read_sheet",
+]

--- a/redcap/dd_redcap/branching.py
+++ b/redcap/dd_redcap/branching.py
@@ -1,0 +1,73 @@
+"""Explain REDCap branching logic in prose.
+
+A REDCap field with *branching logic* is only shown (and so only filled in)
+when a condition on other fields holds, e.g. ``[smoker] = '1'`` or, for one
+checkbox choice, ``[symptoms(3)] = '1'``. Datafile readers see those fields
+as mysteriously blank; this module turns the condition into a sentence for
+the generated description, looking up what the referenced choice value
+*means* in the referenced field's own choice list::
+
+    This variable only records a non-blank value if the value of `smoker`
+    is `1`, _"Yes"_.
+
+Clauses joined by ``and`` are explained clause by clause; anything the three
+recognised patterns do not match is quoted verbatim as a condition.
+"""
+
+from __future__ import annotations
+
+import re
+
+from . import headers
+from .choices import parse_choices
+from .headers import RedCapSheet
+
+# [field(3)] = '1'   — one choice of a checkbox field is ticked
+_CHECKBOX_CHOICE = re.compile(r"\[([A-Za-z0-9_]+)\((\d+)\)\]\s*=\s*['\"]?1[\"']?")
+# [field] = '2'      — a radio/dropdown field has a particular value
+_FIELD_EQUALS = re.compile(r"\[([A-Za-z0-9_]+)\]\s*=\s*['\"]?(\d+)['\"]?")
+# [field] <> ''      — a field is non-blank
+_FIELD_NON_EMPTY = re.compile(r"\[([A-Za-z0-9_]+)\]\s*<>\s*''")
+
+
+def explain_branching_logic(sheet: RedCapSheet, row: list[str]) -> str:
+    """A prose explanation of the row's branching logic, or ``""`` if none."""
+    logic = sheet.get(row, headers.BRANCHING_LOGIC).strip()
+    if not logic:
+        return ""
+    explained = " and ".join(
+        _explain_clause(clause.strip(), sheet) for clause in logic.split(" and ")
+    )
+    return f"This variable only records a non-blank value if {explained}."
+
+
+def _explain_clause(clause: str, sheet: RedCapSheet) -> str:
+    checkbox = _CHECKBOX_CHOICE.fullmatch(clause)
+    equals = _FIELD_EQUALS.fullmatch(clause)
+    non_empty = _FIELD_NON_EMPTY.fullmatch(clause)
+    if checkbox:
+        field, value = checkbox.group(1), checkbox.group(2)
+    elif equals:
+        field, value = equals.group(1), equals.group(2)
+    elif non_empty:
+        field, value = non_empty.group(1), "empty"
+    else:
+        # Fall back to just quoting the expression.
+        return f"the condition `{clause}` evaluates to true"
+
+    label = _choice_label(sheet, field, value)
+    quoted_label = f'_"{label}"_' if label is not None else ""
+    return f"the value of `{field}` is `{value}`, {quoted_label}"
+
+
+def _choice_label(sheet: RedCapSheet, field_id: str, value: str) -> str | None:
+    """What ``value`` means in ``field_id``'s choice list (its label).
+
+    Falls back to the value itself when the referenced field exists but does
+    not list the value; ``None`` when the field is not in the sheet at all.
+    """
+    referenced_row = sheet.row_with_id(field_id)
+    if referenced_row is None:
+        return None
+    choices = parse_choices(sheet.get(referenced_row, headers.CHOICES))
+    return choices.get(value, value)

--- a/redcap/dd_redcap/choices.py
+++ b/redcap/dd_redcap/choices.py
@@ -1,0 +1,44 @@
+"""Parse REDCap's choices notation.
+
+A REDCap ``Choices`` cell lists permissible values as ``value, label`` pairs
+separated by ``|`` — or by ``;`` in older exports that contain no pipe::
+
+    1, Yes | 2, No | 3, Maybe
+
+Only the *first* comma splits value from label, so labels keep their own
+commas (``1, Less than $15,000``). An item with no comma at all is used as
+both value and label.
+"""
+
+from __future__ import annotations
+
+
+def parse_choices(cell: str | None) -> dict[str, str]:
+    """Parse a Choices cell into an ordered ``{value: label}`` mapping.
+
+    ::
+
+        >>> parse_choices("1, Yes | 2, No")
+        {'1': 'Yes', '2': 'No'}
+        >>> parse_choices("1, Less than $15,000 | 2, $15,000 - $19,999")
+        {'1': 'Less than $15,000', '2': '$15,000 - $19,999'}
+        >>> parse_choices("23")
+        {'23': '23'}
+        >>> parse_choices("")
+        {}
+    """
+    if cell is None or not cell.strip():
+        return {}
+    text = cell.strip()
+    separator = "|" if "|" in text else ";"
+    choices: dict[str, str] = {}
+    for item in text.split(separator):
+        item = item.strip()
+        if not item:
+            continue
+        value, comma, label = item.partition(",")
+        if comma:
+            choices[value.strip()] = label.strip()
+        else:
+            choices[item] = item
+    return choices

--- a/redcap/dd_redcap/cli.py
+++ b/redcap/dd_redcap/cli.py
@@ -1,0 +1,56 @@
+"""Command-line interface: convert a REDCap data dictionary.
+
+Usage: ``redcap-to-dd INPUT [-o OUTPUT] [--provenance TEXT]``. INPUT is a
+REDCap data dictionary CSV; the output is a data dictionary CSV in the
+specification's format (stdout unless ``-o`` is given).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from .convert import convert_redcap
+from .headers import ConversionError
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="redcap-to-dd",
+        description="Convert a REDCap data dictionary CSV to a data dictionary CSV.",
+    )
+    parser.add_argument("input", type=Path, help="REDCap data dictionary CSV.")
+    parser.add_argument(
+        "-o", "--output", type=Path, default=None, help="Output file (default: stdout)."
+    )
+    parser.add_argument(
+        "--provenance", default="",
+        help="Text for every element's Provenance column (e.g. the study name).",
+    )
+    return parser
+
+
+def main(argv=None) -> int:
+    args = _build_parser().parse_args(argv)
+    if not args.input.exists():
+        print(f"error: input file not found: {args.input}", file=sys.stderr)
+        return 2
+
+    try:
+        dictionary = convert_redcap(args.input, provenance=args.provenance)
+    except (ConversionError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    csv_text = dictionary.to_csv()
+    if args.output is None:
+        sys.stdout.write(csv_text)
+    else:
+        args.output.write_text(csv_text, encoding="utf-8")
+        print(f"Wrote {len(dictionary)} data elements to {args.output}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/redcap/dd_redcap/convert.py
+++ b/redcap/dd_redcap/convert.py
@@ -1,0 +1,142 @@
+"""Convert a REDCap data dictionary into the toolkit's model.
+
+One REDCap row becomes one :class:`~dd_api.DataElement` (rows of Field Type
+``descriptive`` are display text, not fields, and are skipped). The result is
+a :class:`~dd_api.DataDictionary`, so writing the converted dictionary out is
+just ``dd.to_csv()`` and everything downstream (printer, validator, LinkML)
+works on it directly.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import TextIO
+
+from dd_api import DataDictionary, DataElement, EnumItem
+
+from . import headers
+from .branching import explain_branching_logic
+from .choices import parse_choices
+from .datatypes import extract_datatype
+from .headers import RedCapSheet, read_sheet
+
+logger = logging.getLogger(__name__)
+
+# A @NONEOFTHEABOVE field-annotation action names the choice values that are
+# mutually exclusive with all others, e.g. @NONEOFTHEABOVE = '98,99'.
+_NONE_OF_THE_ABOVE = re.compile(r"@NONEOFTHEABOVE\s*=\s*['\"](\d+)((?:,\d+)*)['\"]")
+
+
+def convert_redcap(source: str | Path | TextIO, *, provenance: str = "") -> DataDictionary:
+    """Convert a REDCap data dictionary CSV into a :class:`DataDictionary`.
+
+    ``source`` may be a path or an open text file; ``provenance`` fills every
+    element's Provenance column (e.g. the study or instrument name). Raises
+    :class:`~dd_redcap.ConversionError` when the file is not a REDCap
+    dictionary, and ``ValueError`` when two rows share a Variable name.
+    """
+    sheet = read_sheet(source)
+    elements: list[DataElement] = []
+    current_section = ""
+    for row in sheet.rows:
+        field_type = sheet.get(row, headers.FIELD_TYPE)
+        if field_type == "descriptive":
+            continue  # display text on the form, not a data field
+        # Section headers are not filled down in REDCap exports: a blank cell
+        # means "still in the previous section".
+        if sheet.get(row, headers.SECTION_HEADER):
+            current_section = sheet.get(row, headers.SECTION_HEADER)
+        field_id = sheet.get(row, headers.VARIABLE)
+        if not field_id:
+            logger.warning("Skipping a row with no Variable / Field Name value.")
+            continue
+        elements.append(_element_from_row(sheet, row, field_id, current_section, provenance))
+    return DataDictionary(elements)
+
+
+def _element_from_row(
+    sheet: RedCapSheet, row: list[str], field_id: str, section: str, provenance: str
+) -> DataElement:
+    label = _build_label(sheet, row)
+    choices = parse_choices(sheet.get(row, headers.CHOICES))
+    datatype = extract_datatype(sheet, row)
+    return DataElement(
+        id=field_id,
+        label=label,
+        datatype=datatype,
+        description=_build_description(sheet, row, field_id, label, choices, datatype),
+        section=section or None,
+        cardinality="multiple" if sheet.get(row, headers.FIELD_TYPE) == "checkbox" else "single",
+        enumeration=tuple(
+            EnumItem(value=value, label=choice_label) for value, choice_label in choices.items()
+        ),
+        notes=_notes_from_annotations(sheet, row) or None,
+        provenance=provenance or None,
+    )
+
+
+def _build_label(sheet: RedCapSheet, row: list[str]) -> str:
+    """The Field Label, with a non-blank Field Note appended in parentheses."""
+    label = sheet.get(row, headers.FIELD_LABEL)
+    note = sheet.get(row, headers.FIELD_NOTE)
+    return f"{label} ({note})" if note else label
+
+
+def _build_description(
+    sheet: RedCapSheet,
+    row: list[str],
+    field_id: str,
+    label: str,
+    choices: dict[str, str],
+    datatype: str,
+) -> str:
+    """Generated prose: the prompt, the permissible values, the branching logic."""
+    paragraphs = [
+        f'The `{field_id}` variable records response to the prompt, _"{label}"_.',
+        _describe_values(sheet, row, choices, datatype),
+        explain_branching_logic(sheet, row),
+    ]
+    return "\n\n".join(paragraph for paragraph in paragraphs if paragraph)
+
+
+def _describe_values(
+    sheet: RedCapSheet, row: list[str], choices: dict[str, str], datatype: str
+) -> str:
+    """A sentence about the permissible values, for enumerated fields."""
+    if not choices:
+        return ""
+    sentence = (
+        f"Values for this variable are {datatype}s that are restricted to the "
+        f"list of {len(choices)} permissible {datatype} values."
+    )
+    exclusive = _mutually_exclusive_values(sheet, row)
+    if exclusive:
+        listed = ",".join(f"`{value}`" for value in exclusive)
+        word, verb = ("value", "is") if len(exclusive) == 1 else ("values", "are")
+        sentence += (
+            f"  The {word} {listed} {verb} mutually exclusive with any other values."
+        )
+    return sentence
+
+
+def _mutually_exclusive_values(sheet: RedCapSheet, row: list[str]) -> list[str]:
+    """Choice values named by @NONEOFTHEABOVE actions in the Field Annotation."""
+    values: list[str] = []
+    for annotation in sheet.get(row, headers.FIELD_ANNOTATION).split("|"):
+        match = _NONE_OF_THE_ABOVE.search(annotation)
+        if match:
+            values.extend(v.strip() for v in (match.group(1) + match.group(2)).split(","))
+    return values
+
+
+def _notes_from_annotations(sheet: RedCapSheet, row: list[str]) -> str:
+    """Field Annotation entries as Notes paragraphs.
+
+    ``@NONEOFTHEABOVE`` actions are dropped — they are already explained in
+    the generated description.
+    """
+    annotations = sheet.get(row, headers.FIELD_ANNOTATION).split("|")
+    kept = [a.strip() for a in annotations if a.strip() and not _NONE_OF_THE_ABOVE.search(a)]
+    return "\n\n".join(kept)

--- a/redcap/dd_redcap/datatypes.py
+++ b/redcap/dd_redcap/datatypes.py
@@ -1,0 +1,64 @@
+"""Map REDCap validation types to the specification's datatype names.
+
+A REDCap text field carries its format in the ``Text Validation Type`` column
+(``integer``, ``number_2dp``, ``date_mdy``, ``zipcode``, …). This table maps
+each validation name to a datatype name from the data dictionary
+specification. Formats with no structured counterpart (ids, emails, phone
+numbers, partial dates) map to ``string`` — never silently to something
+stricter than the data warrants.
+"""
+
+from __future__ import annotations
+
+from . import headers
+from .choices import parse_choices
+from .headers import RedCapSheet
+
+# REDCap validation name (lowercase) -> spec datatype name.
+VALIDATION_DATATYPES: dict[str, str] = {
+    "integer": "integer",
+    "number": "decimal",
+    "number_1dp": "decimal",
+    "number_2dp": "decimal",
+    "number_3dp": "decimal",
+    "number_4dp": "decimal",
+    "date_ymd": "date",  # Y-M-D is the XSD lexical form of a date
+    "date_mdy": "date_mdy",
+    "date_dmy": "date_dmy",
+    "datetime_seconds_ymd": "dateTime",
+    "datetime_seconds_mdy": "date_mdy",
+    "datetime_seconds_dmy": "date_dmy",
+    "time": "time",
+    "time_hh_mm_ss": "time",
+    # Formats with no structured spec counterpart -> string:
+    # alpha_id, alpha-dash, custom_id, dash-id, email, ip_address, lab_value,
+    # alpha_only, mac_address, mrn_78d, phone, zipcode, api_token, sunet_id,
+    # date_my, date_ym (partial dates are not valid xsd:date values), ...
+}
+
+_DEFAULT = "string"
+
+
+def extract_datatype(sheet: RedCapSheet, row: list[str]) -> str:
+    """The spec datatype name for one REDCap row.
+
+    A field with choices is typed by its choice values: ``integer`` when the
+    first value is all digits, ``string`` otherwise. A text field is typed by
+    its validation name via :data:`VALIDATION_DATATYPES`, with one REDCap
+    idiosyncrasy honoured: validation ``text`` plus a ``MM/DD/YYYY`` field
+    note means a US-format date (``date_mdy``). Everything unrecognised is
+    ``string``.
+    """
+    choices = parse_choices(sheet.get(row, headers.CHOICES))
+    if choices:
+        first_value = next(iter(choices))
+        return "integer" if first_value.isdigit() else "string"
+
+    validation = sheet.get(row, headers.TEXT_VALIDATION).lower()
+    if not validation:
+        return _DEFAULT
+    if validation == "text":
+        note = sheet.get(row, headers.FIELD_NOTE)
+        if note.strip().upper() == "MM/DD/YYYY":
+            return "date_mdy"
+    return VALIDATION_DATATYPES.get(validation, _DEFAULT)

--- a/redcap/dd_redcap/headers.py
+++ b/redcap/dd_redcap/headers.py
@@ -1,0 +1,115 @@
+"""The REDCap column vocabulary, and reading a REDCap sheet by column name.
+
+REDCap exports name their columns verbosely (``Variable / Field Name``,
+``Choices, Calculations, OR Slider Labels``), and hand-edited copies often
+shorten them. Each column here carries its synonyms; matching is
+case-insensitive on the trimmed header text.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import TextIO
+
+# Canonical REDCap column name -> accepted spellings (all compared lowercase).
+_SYNONYMS: dict[str, tuple[str, ...]] = {
+    "Variable / Field Name": ("variable", "field name"),
+    "Form Name": (),
+    "Section Header": ("section",),
+    "Field Type": ("type",),
+    "Field Label": ("label", "prompt"),
+    "Choices, Calculations, OR Slider Labels": ("choices",),
+    "Field Note": (),
+    "Text Validation Type OR Show Slider Number": ("text validation",),
+    "Text Validation Min": (),
+    "Text Validation Max": (),
+    "Identifier?": (),
+    "Branching Logic (Show field only if...)": ("branching logic",),
+    "Required Field?": (),
+    "Custom Alignment": (),
+    "Question Number (surveys only)": (),
+    "Matrix Group Name": (),
+    "Matrix Ranking?": (),
+    "Field Annotation": (),
+}
+
+# Short names used throughout the package, mapped to the canonical header.
+VARIABLE = "Variable / Field Name"
+SECTION_HEADER = "Section Header"
+FIELD_TYPE = "Field Type"
+FIELD_LABEL = "Field Label"
+CHOICES = "Choices, Calculations, OR Slider Labels"
+FIELD_NOTE = "Field Note"
+TEXT_VALIDATION = "Text Validation Type OR Show Slider Number"
+BRANCHING_LOGIC = "Branching Logic (Show field only if...)"
+FIELD_ANNOTATION = "Field Annotation"
+
+
+class ConversionError(ValueError):
+    """Raised when a file cannot be converted (e.g. no Variable column)."""
+
+
+class RedCapSheet:
+    """A parsed REDCap data dictionary CSV, addressable by canonical column.
+
+    ``sheet.get(row, VARIABLE)`` returns the cell for the Variable column of
+    ``row`` (an index into :attr:`rows`), or ``""`` when the column is absent
+    or the cell blank — sparse, hand-edited exports are the norm.
+    """
+
+    def __init__(self, header: list[str], rows: list[list[str]]):
+        self.rows = rows
+        self._column_index: dict[str, int] = {}
+        normalised = [cell.strip().lower() for cell in header]
+        for canonical, synonyms in _SYNONYMS.items():
+            accepted = {canonical.lower(), *synonyms}
+            for index, header_cell in enumerate(normalised):
+                if header_cell in accepted:
+                    self._column_index[canonical] = index
+                    break
+
+    def has_column(self, canonical: str) -> bool:
+        return canonical in self._column_index
+
+    def get(self, row: list[str], canonical: str) -> str:
+        """The (stripped) cell of ``row`` for a canonical column, else ``""``."""
+        index = self._column_index.get(canonical)
+        if index is None or index >= len(row):
+            return ""
+        return row[index].strip()
+
+    def row_with_id(self, field_id: str) -> list[str] | None:
+        """The first data row whose Variable cell equals ``field_id``."""
+        for row in self.rows:
+            if self.get(row, VARIABLE) == field_id:
+                return row
+        return None
+
+
+def read_sheet(source: str | Path | TextIO) -> RedCapSheet:
+    """Read a REDCap data dictionary CSV into a :class:`RedCapSheet`.
+
+    Raises :class:`ConversionError` if the file is empty or has no
+    recognisable Variable / Field Name column (it is not a REDCap dictionary).
+    """
+    if isinstance(source, (str, Path)):
+        with open(source, encoding="utf-8-sig", newline="") as handle:
+            return _read(handle)
+    return _read(source)
+
+
+def _read(handle: TextIO) -> RedCapSheet:
+    reader = csv.reader(handle)
+    try:
+        header = next(reader)
+    except StopIteration:
+        raise ConversionError("The file is empty (no header record).") from None
+    rows = [row for row in reader if any(cell.strip() for cell in row)]
+    sheet = RedCapSheet(header, rows)
+    if not sheet.has_column(VARIABLE):
+        raise ConversionError(
+            "No 'Variable / Field Name' column found — this does not look "
+            "like a REDCap data dictionary."
+        )
+    return sheet

--- a/redcap/pyproject.toml
+++ b/redcap/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dd-redcap"
+version = "0.0.1"
+description = "Convert a REDCap data dictionary to the data dictionary specification's format"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "BSD-2-Clause" }
+dependencies = [
+    # The converted dictionary is built as dd_api model objects, so output is
+    # canonical by construction. Not on PyPI; depend directly on this repo.
+    "dd-api @ git+https://github.com/bmir-radx/radx-data-dictionary-specification.git#subdirectory=api",
+]
+
+[project.optional-dependencies]
+test = ["pytest>=7"]
+
+[project.scripts]
+redcap-to-dd = "dd_redcap.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["dd_redcap*"]
+
+[tool.pytest.ini_options]
+# Docstring examples run as doctests, as in the api package.
+testpaths = ["tests", "dd_redcap"]
+addopts = "--doctest-modules"
+doctest_optionflags = "ELLIPSIS NORMALIZE_WHITESPACE"

--- a/redcap/tests/test_choices.py
+++ b/redcap/tests/test_choices.py
@@ -1,0 +1,40 @@
+"""Choices-parser tests, including every case from the Java test suite."""
+
+import pytest
+from dd_redcap.choices import parse_choices
+
+
+@pytest.mark.parametrize("empty", [None, "", "   "])
+def test_empty_choice_list(empty):
+    assert parse_choices(empty) == {}
+
+
+def test_single_value():
+    assert parse_choices("23") == {"23": "23"}
+
+
+def test_single_value_label():
+    assert parse_choices("22, Hello") == {"22": "Hello"}
+
+
+def test_multiple_choices_with_pipe():
+    assert parse_choices("1, Yes | 2, No | 3, Maybe") == {"1": "Yes", "2": "No", "3": "Maybe"}
+
+
+def test_pipe_wins_over_semicolons():
+    # A pipe-separated list whose labels contain semicolons.
+    result = parse_choices("1, Yes; Possibly | 2, No | 3, Maybe")
+    assert result == {"1": "Yes; Possibly", "2": "No", "3": "Maybe"}
+
+
+def test_semicolon_separated():
+    assert parse_choices("1, Yes ; 2, No ; 3, Maybe") == {"1": "Yes", "2": "No", "3": "Maybe"}
+
+
+def test_labels_keep_their_commas():
+    result = parse_choices("1, Less than $15,000 | 2, $15,000 - $19,999")
+    assert result == {"1": "Less than $15,000", "2": "$15,000 - $19,999"}
+
+
+def test_order_preserved():
+    assert list(parse_choices("3, C | 1, A | 2, B")) == ["3", "1", "2"]

--- a/redcap/tests/test_convert.py
+++ b/redcap/tests/test_convert.py
@@ -1,0 +1,132 @@
+"""Converter tests: REDCap rows -> DataElements."""
+
+import io
+
+import pytest
+from dd_api import DataDictionary
+from dd_redcap import ConversionError, convert_redcap
+
+HEADER = (
+    "Variable / Field Name,Form Name,Section Header,Field Type,Field Label,"
+    '"Choices, Calculations, OR Slider Labels",Field Note,'
+    "Text Validation Type OR Show Slider Number,Text Validation Min,"
+    "Text Validation Max,Identifier?,Branching Logic (Show field only if...),"
+    "Required Field?,Custom Alignment,Question Number (surveys only),"
+    "Matrix Group Name,Matrix Ranking?,Field Annotation"
+)
+
+
+def _convert(rows, **kwargs):
+    return convert_redcap(io.StringIO(HEADER + "\n" + "\n".join(rows) + "\n"), **kwargs)
+
+
+def test_basic_text_field():
+    dd = _convert(["age,form1,,text,Age in years,,,integer,,,,,,,,,,"])
+    element = dd["age"]
+    assert element.label == "Age in years"
+    assert element.datatype == "integer"
+    assert element.cardinality == "single"
+    assert not element.is_enumerated
+
+
+def test_field_note_appended_to_label():
+    dd = _convert(["age,form1,,text,Age,,in years,integer,,,,,,,,,,"])
+    assert dd["age"].label == "Age (in years)"
+
+
+def test_choices_become_enumeration():
+    dd = _convert(['sex,form1,,radio,Sex,"1, Male | 2, Female",,,,,,,,,,,,'])
+    element = dd["sex"]
+    assert [(c.value, c.label) for c in element.enumeration] == [("1", "Male"), ("2", "Female")]
+    assert element.datatype == "integer"  # first choice value is all digits
+    assert "2 permissible integer values" in element.description
+
+
+def test_non_numeric_choices_are_strings():
+    dd = _convert(['grp,form1,,dropdown,Group,"a, Alpha | b, Beta",,,,,,,,,,,,'])
+    assert dd["grp"].datatype == "string"
+
+
+def test_checkbox_is_multivalued():
+    dd = _convert(['sym,form1,,checkbox,Symptoms,"1, Cough | 2, Fever",,,,,,,,,,,,'])
+    assert dd["sym"].is_multivalued
+
+
+def test_sections_carry_forward():
+    dd = _convert(
+        [
+            "a,form1,Demographics,text,A,,,,,,,,,,,,,",
+            "b,form1,,text,B,,,,,,,,,,,,,",
+            "c,form1,Vitals,text,C,,,,,,,,,,,,,",
+        ]
+    )
+    assert [e.section for e in dd] == ["Demographics", "Demographics", "Vitals"]
+
+
+def test_descriptive_rows_are_skipped():
+    dd = _convert(
+        [
+            "blurb,form1,,descriptive,Please answer the following,,,,,,,,,,,,,",
+            "a,form1,,text,A,,,,,,,,,,,,,",
+        ]
+    )
+    assert dd.ids == ("a",)
+
+
+def test_branching_logic_explained_with_choice_label():
+    dd = _convert(
+        [
+            'smoker,form1,,radio,Do you smoke?,"0, No | 1, Yes",,,,,,,,,,,,',
+            "packs,form1,,text,Packs per day,,,number,,,,[smoker] = '1',,,,,,",
+        ]
+    )
+    description = dd["packs"].description
+    assert "only records a non-blank value if" in description
+    assert "the value of `smoker` is `1`" in description
+    assert '_"Yes"_' in description
+    assert dd["packs"].datatype == "decimal"  # validation "number" -> decimal
+
+
+def test_unrecognised_branching_logic_quoted():
+    dd = _convert(["x,form1,,text,X,,,,,,,[bmi] > 30,,,,,,"])
+    assert "the condition `[bmi] > 30` evaluates to true" in dd["x"].description
+
+
+def test_none_of_the_above_annotation():
+    dd = _convert(
+        [
+            'sym,form1,,checkbox,Symptoms,"1, Cough | 99, None",,,,,,,,,,,,'
+            "@NONEOFTHEABOVE = '99'",
+        ]
+    )
+    element = dd["sym"]
+    assert "`99` is mutually exclusive with any other values" in element.description
+    assert element.notes is None  # the action is explained, not kept as a note
+
+
+def test_other_annotations_become_notes():
+    dd = _convert(["a,form1,,text,A,,,,,,,,,,,,,@HIDDEN | @READONLY"])
+    assert dd["a"].notes == "@HIDDEN\n\n@READONLY"
+
+
+def test_provenance_fills_every_element():
+    dd = _convert(["a,form1,,text,A,,,,,,,,,,,,,"], provenance="My Study")
+    assert dd["a"].provenance == "My Study"
+
+
+def test_output_round_trips_through_the_model():
+    dd = _convert(['sex,form1,,radio,Sex,"1, Male | 2, Female",,,,,,,,,,,,'])
+    reloaded = DataDictionary.load(io.StringIO(dd.to_csv()))
+    assert reloaded.elements == dd.elements
+
+
+def test_not_a_redcap_file_raises():
+    with pytest.raises(ConversionError, match="Variable / Field Name"):
+        convert_redcap(io.StringIO("Id,Label,Datatype\na,A,string\n"))
+
+
+def test_synonym_headers_accepted():
+    text = "Variable,Label,Type\nage,Age,text\n"
+    dd = convert_redcap(io.StringIO(text))
+    assert dd["age"].label == "Age"
+    assert dd["age"].datatype == "string"

--- a/redcap/tests/test_datatypes_and_cli.py
+++ b/redcap/tests/test_datatypes_and_cli.py
@@ -1,0 +1,86 @@
+"""Datatype-mapping and CLI tests."""
+
+import io
+
+import pytest
+from dd_api import DataDictionary
+from dd_redcap import convert_redcap
+from dd_redcap.cli import main
+
+_HEADER = "Variable,Label,Type,Field Note,Text Validation\n"
+
+
+def _element(validation, note=""):
+    text = _HEADER + f"f,F,text,{note},{validation}\n"
+    return convert_redcap(io.StringIO(text))["f"]
+
+
+@pytest.mark.parametrize(
+    "validation, expected",
+    [
+        ("integer", "integer"),
+        ("number", "decimal"),
+        ("number_2dp", "decimal"),
+        ("date_ymd", "date"),
+        ("date_mdy", "date_mdy"),
+        ("date_dmy", "date_dmy"),
+        ("datetime_seconds_ymd", "dateTime"),
+        ("time", "time"),
+        ("time_hh_mm_ss", "time"),
+        ("email", "string"),
+        ("zipcode", "string"),
+        ("phone", "string"),
+        ("", "string"),
+        ("something_unknown", "string"),
+    ],
+)
+def test_validation_datatype_mapping(validation, expected):
+    assert _element(validation).datatype == expected
+
+
+def test_text_validation_with_us_date_note():
+    assert _element("text", note="MM/DD/YYYY").datatype == "date_mdy"
+
+
+def test_every_mapped_datatype_is_valid_in_the_model():
+    # Round-trip guarantee: whatever the table maps to must load.
+    from dd_redcap.datatypes import VALIDATION_DATATYPES
+
+    for name in set(VALIDATION_DATATYPES.values()):
+        dd = DataDictionary.from_rows([{"Id": "x", "Label": "X", "Datatype": name}])
+        assert dd["x"].datatype == name
+
+
+# --- CLI ----------------------------------------------------------------------
+
+REDCAP_SAMPLE = 'Variable,Label,Type,Choices\nsex,Sex,radio,"1, Male | 2, Female"\n'
+
+
+def test_cli_writes_output_file(tmp_path, capsys):
+    src = tmp_path / "redcap.csv"
+    src.write_text(REDCAP_SAMPLE)
+    out = tmp_path / "dd.csv"
+    assert main([str(src), "-o", str(out), "--provenance", "Study X"]) == 0
+    dd = DataDictionary.load(out)
+    assert dd["sex"].provenance == "Study X"
+    assert [c.label for c in dd["sex"].enumeration] == ["Male", "Female"]
+    assert "1 data elements" in capsys.readouterr().err
+
+
+def test_cli_stdout_by_default(tmp_path, capsys):
+    src = tmp_path / "redcap.csv"
+    src.write_text(REDCAP_SAMPLE)
+    assert main([str(src)]) == 0
+    assert capsys.readouterr().out.startswith("Id,Aliases,Label,")
+
+
+def test_cli_missing_input_exits_two(capsys):
+    assert main(["/no/such/file.csv"]) == 2
+    assert "not found" in capsys.readouterr().err
+
+
+def test_cli_non_redcap_input_exits_one(tmp_path, capsys):
+    src = tmp_path / "notredcap.csv"
+    src.write_text("Id,Label,Datatype\na,A,string\n")
+    assert main([str(src)]) == 1
+    assert "error:" in capsys.readouterr().err


### PR DESCRIPTION
Adds `redcap/` (package `dd_redcap`, command `redcap-to-dd`): converts a **REDCap data dictionary export** into this specification's format. Ported from the Java [redcap-data-dictionary-converter](https://github.com/matthewhorridge); design record in [`redcap/REDCAP_PLAN.md`](redcap/REDCAP_PLAN.md).

Built on `dd_api`: one REDCap row → one `DataElement`, output written by `DataDictionary.to_csv()`, so the result is canonical by construction and immediately works with the printer, validator, and LinkML converter.

**Mapping**: Variable → Id; Field Label (+ Field Note in parens) → Label; Section Header carried forward; `checkbox` → `multiple`; `1, Yes | 2, No` choices → Enumeration; Field Annotation → Notes; `--provenance` → Provenance. Generated prose descriptions cover the prompt, permissible-value counts, mutually exclusive values (`@NONEOFTHEABOVE`), and plain-English branching-logic explanations with choice labels resolved from the referenced field.

**One deliberate departure (user-confirmed)**: the Java's rich validation-type table was dead code — the live path recognised only 8 exact names and silently stringed the rest. The port implements the intended mapping as one explicit table (`number` → `decimal`, `date_ymd` → `date`, `datetime_seconds_ymd` → `dateTime`, ids/emails/phones → `string`), with a test asserting every mapped name is valid in the model.

**Verification**: 46 tests (every Java choices-parser case ported, model round-trip, CLI); ruff-clean; other suites unaffected (api 42, converter 147).

🤖 Generated with [Claude Code](https://claude.com/claude-code)