### PR TITLE
Add community scaffolding: CI, contributing guide, and health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: Bug report
+description: Something isn't working as documented
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: package
+    attributes:
+      label: Which package?
+      options:
+        - dd-core (core)
+        - dd-linkml (linkml)
+        - dd-validate (validator)
+        - dd-api (api)
+        - dd-print (printer)
+        - dd-redcap (redcap)
+        - the specification itself
+        - not sure
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect, and what happened instead?
+      placeholder: |
+        1. Ran `dd-validate my.csv`
+        2. Expected ...
+        3. Got ...
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal example
+      description: >-
+        The smallest input (a few CSV rows, a snippet) and command that
+        reproduce the problem. Paste text, not screenshots, where you can.
+      render: text
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: "Package version or commit (e.g. `pip show dd-api` / the tag you installed)."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/bmir-radx/radx-data-dictionary-specification/security/advisories/new
+    about: Please report security issues privately, not as a public issue. See SECURITY.md.
+  - name: Question or discussion
+    url: https://github.com/bmir-radx/radx-data-dictionary-specification/discussions
+    about: For usage questions and open-ended discussion.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,21 @@
+name: Feature request
+description: Suggest an improvement or new capability
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: The use case or limitation you're running into. Focus on the "why".
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What you'd like to happen. Sketch the CLI/API shape if you have one in mind.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you've thought about.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!-- Thanks for contributing! A few reminders below. -->
+
+## What and why
+
+<!-- What does this change, and what problem does it solve? Link any issue. -->
+
+## Checklist
+
+- [ ] `ruff check` passes
+- [ ] `pytest` passes for each affected package
+- [ ] Updated [`SPECIFICATION.md`](../SPECIFICATION.md) if this changes specified behaviour
+- [ ] Updated the relevant plan/design doc if this changes an algorithm
+- [ ] **Release label set** — every merge to `main` cuts a release:
+  `release:minor` (new feature), `release:major` (breaking), `release:skip`
+  (docs/CI/chore only), or leave unlabelled for a patch bump.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,20 +45,20 @@ jobs:
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip
-          # Two passes. First install every sibling from the local checkout with
-          # --no-deps, in dependency order: this makes each dd-* importable and,
-          # crucially, satisfies the pinned "dd-* @ git+...@vX.Y.Z" requirements
-          # so the second pass never refetches a sibling from GitHub (which would
-          # test released code, not the code under review).
+          # Install the third-party runtime + test dependencies of all packages
+          # explicitly. We must NOT install the packages with their own deps
+          # resolved, because their "dd-* @ git+...@vX.Y.Z" URLs would make pip
+          # clone released siblings from GitHub and shadow the local editable
+          # copies (two copies of dd_core on sys.path -> pytest "import file
+          # mismatch"). This is the union of every package's dependencies and
+          # [test] extras; it's small and CONTRIBUTING.md documents it.
+          pip install \
+            "lark>=1.1" "linkml>=1.8" pyyaml "jinja2>=3" "markdown-it-py[linkify]>=3" \
+            "jsonschema>=4" "pytest>=7"
+          # Now the local packages with --no-deps, in dependency order, so each
+          # dd-* is editable and importable and nothing is fetched from git.
           for pkg in core linkml validator api printer redcap; do
             pip install --no-deps -e "./${pkg}"
-          done
-          # Second pass: a normal editable install per package pulls each one's
-          # third-party runtime + test dependencies (lark, linkml, jinja2,
-          # markdown-it-py, pyyaml, jsonschema, pytest, ...) straight from its
-          # own pyproject, so this list never has to be maintained by hand.
-          for pkg in core linkml validator api printer redcap; do
-            pip install -e "./${pkg}[test]" || pip install -e "./${pkg}"
           done
 
       - name: Run tests for every package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: CI
+
+# Lint and test every package on each push and pull request. This runs BEFORE
+# the release workflow can act on main, so a broken change never gets released.
+#
+# The packages depend on each other (core -> linkml/validator -> api ->
+# printer/redcap) via pinned git URLs in their pyproject.toml. CI must NOT let
+# those git URLs win, or a PR that breaks core would be tested against the last
+# *released* core instead of the code under review. So we install every sibling
+# from the local checkout, in dependency order, with --no-deps.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: check --output-format=github
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Test the floor and a current version. requires-python is >=3.9.
+        python-version: ["3.9", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install all packages from the local checkout (in dependency order)
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          # Two passes. First install every sibling from the local checkout with
+          # --no-deps, in dependency order: this makes each dd-* importable and,
+          # crucially, satisfies the pinned "dd-* @ git+...@vX.Y.Z" requirements
+          # so the second pass never refetches a sibling from GitHub (which would
+          # test released code, not the code under review).
+          for pkg in core linkml validator api printer redcap; do
+            pip install --no-deps -e "./${pkg}"
+          done
+          # Second pass: a normal editable install per package pulls each one's
+          # third-party runtime + test dependencies (lark, linkml, jinja2,
+          # markdown-it-py, pyyaml, jsonschema, pytest, ...) straight from its
+          # own pyproject, so this list never has to be maintained by hand.
+          for pkg in core linkml validator api printer redcap; do
+            pip install -e "./${pkg}[test]" || pip install -e "./${pkg}"
+          done
+
+      - name: Run tests for every package
+        run: |
+          set -euxo pipefail
+          # Each package's pyproject drives its own testpaths and doctest opts
+          # (api and redcap run --doctest-modules; the rest run tests/ only).
+          for pkg in core linkml validator api printer redcap; do
+            echo "::group::pytest ${pkg}"
+            ( cd "${pkg}" && pytest )
+            echo "::endgroup::"
+          done

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,21 @@
+cff-version: 1.2.0
+message: "If you use this software or specification, please cite it as below."
+title: "Data Dictionary Specification and Toolkit"
+abstract: >-
+  A specification for data dictionaries describing the structure of tabular
+  datafiles as an ordered list of data elements, with a CSV and an equivalent
+  LinkML serialization, and a toolkit of Python packages that convert, validate,
+  render, and programmatically manipulate them.
+type: software
+authors:
+  - family-names: Horridge
+    given-names: Matthew
+    affiliation: "Stanford Center for Biomedical Informatics Research"
+repository-code: "https://github.com/bmir-radx/radx-data-dictionary-specification"
+license: BSD-2-Clause
+keywords:
+  - data dictionary
+  - metadata
+  - LinkML
+  - REDCap
+  - FAIR data

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and maintainers pledge to make participation in
+this project a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Focusing on what is best for the community and the project
+- Showing empathy toward other community members
+
+Unacceptable behavior includes harassment, insulting or derogatory comments,
+personal or political attacks, public or private harassment, and publishing
+others' private information without permission.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers at **horridge@stanford.edu**. All complaints will be
+reviewed and investigated promptly and fairly, and the maintainers will respect
+the privacy and security of the reporter.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,22 +22,24 @@ All six share one version number.
 
 ## Development setup
 
-Clone the repo and install the packages **from the local checkout**, in
-dependency order, into a virtual environment. Install siblings with `--no-deps`
-first so the pinned `dd-* @ git+...` URLs in each `pyproject.toml` don't pull
-released code over the code you're editing:
+Clone the repo and install the packages **from the local checkout** into a
+virtual environment. Install the third-party dependencies explicitly first, then
+the local packages with `--no-deps` — this is important: the pinned
+`dd-* @ git+...` URLs in each `pyproject.toml` would otherwise make pip clone the
+last *released* siblings from GitHub and shadow the code you're editing.
 
 ```sh
 python -m venv .venv && source .venv/bin/activate
 pip install --upgrade pip
 
-# First pass: local, importable, in dependency order (no git refetch).
+# Third-party runtime + test deps (the union across all packages).
+pip install "lark>=1.1" "linkml>=1.8" pyyaml "jinja2>=3" \
+    "markdown-it-py[linkify]>=3" "jsonschema>=4" "pytest>=7"
+
+# Local packages, editable, in dependency order, with --no-deps so no sibling
+# is fetched from git.
 for pkg in core linkml validator api printer redcap; do
     pip install --no-deps -e "./$pkg"
-done
-# Second pass: pull each package's third-party + test dependencies.
-for pkg in core linkml validator api printer redcap; do
-    pip install -e "./$pkg[test]" || pip install -e "./$pkg"
 done
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing
+
+Thanks for your interest in improving the Data Dictionary Specification and its
+tooling. This repo is a small monorepo of six Python packages built on one
+[specification](SPECIFICATION.md); contributions to any of them — or to the
+spec itself — are welcome.
+
+## Repository layout
+
+Each directory is an independent, pip-installable package:
+
+| Package | Distribution | Depends on |
+| --- | --- | --- |
+| [`core/`](core/) | `dd-core` | — |
+| [`linkml/`](linkml/) | `dd-linkml` | core |
+| [`validator/`](validator/) | `dd-validate` | core |
+| [`api/`](api/) | `dd-api` | core, linkml |
+| [`printer/`](printer/) | `dd-print` | api |
+| [`redcap/`](redcap/) | `dd-redcap` | api |
+
+All six share one version number.
+
+## Development setup
+
+Clone the repo and install the packages **from the local checkout**, in
+dependency order, into a virtual environment. Install siblings with `--no-deps`
+first so the pinned `dd-* @ git+...` URLs in each `pyproject.toml` don't pull
+released code over the code you're editing:
+
+```sh
+python -m venv .venv && source .venv/bin/activate
+pip install --upgrade pip
+
+# First pass: local, importable, in dependency order (no git refetch).
+for pkg in core linkml validator api printer redcap; do
+    pip install --no-deps -e "./$pkg"
+done
+# Second pass: pull each package's third-party + test dependencies.
+for pkg in core linkml validator api printer redcap; do
+    pip install -e "./$pkg[test]" || pip install -e "./$pkg"
+done
+```
+
+## Running the checks
+
+CI runs exactly these two things; run them locally before opening a PR:
+
+```sh
+# Lint (uses the root ruff.toml).
+ruff check
+
+# Test each package (each package's pyproject drives its own testpaths and
+# doctest options; api and redcap run their docstring examples as doctests).
+for pkg in core linkml validator api printer redcap; do
+    ( cd "$pkg" && pytest )
+done
+```
+
+## Conventions
+
+- **Python ≥ 3.9.** CI tests on 3.9 and 3.12; don't use syntax newer than 3.9.
+- **Lint with ruff** (`F,E,W,B,C4,UP,SIM,I` at 100 columns — see `ruff.toml`).
+- **reStructuredText docstrings.** Public API examples are executable doctests
+  (`api`, `redcap`) — keep them passing; they are how the docs stay honest.
+- **The Markdown [`SPECIFICATION.md`](SPECIFICATION.md) is authoritative.** If a
+  change alters behaviour the spec describes, update the spec in the same PR.
+- **A design/plan doc per tool.** Larger tools carry a plan or conversion
+  document (e.g. `linkml/CONVERTER_PLAN.md`, `redcap/CONVERSION.md`); update it
+  when you change the algorithm it describes.
+
+## Pull requests and releases
+
+Every merge to `main` automatically cuts a release (version bump + tag + GitHub
+release), which is what lets users `pipx upgrade` the tools. The bump size comes
+from the PR's labels:
+
+| Label | Effect |
+| --- | --- |
+| `release:major` | major bump (`X`.0.0) |
+| `release:minor` | minor bump (x.`Y`.0) |
+| *(none)* | patch bump (x.y.`Z`) — the default |
+| `release:skip` | no release (docs-only / CI-only changes) |
+
+So: label user-facing feature PRs `release:minor`, breaking changes
+`release:major`, and label pure docs/CI/chore PRs `release:skip`. If you forget,
+a patch release is cut — harmless but noisy.
+
+## Reporting bugs and requesting features
+
+Open an issue using one of the [templates](.github/ISSUE_TEMPLATE). For security
+issues, please follow [SECURITY.md](SECURITY.md) instead of filing a public
+issue.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Data Dictionary Specification
 
+[![CI](https://github.com/bmir-radx/radx-data-dictionary-specification/actions/workflows/ci.yml/badge.svg)](https://github.com/bmir-radx/radx-data-dictionary-specification/actions/workflows/ci.yml)
+[![License: BSD-2-Clause](https://img.shields.io/badge/License-BSD--2--Clause-blue.svg)](LICENSE)
+[![Python](https://img.shields.io/badge/python-%E2%89%A53.9-blue.svg)](https://www.python.org/)
+
 A specification for **data dictionaries**. A data dictionary describes the
 structure of a tabular *datafile* as an ordered list of *data elements* where each 
 data element represents a column in the data file, defining its field's identifier (variable name), 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security problems.
+
+Instead, report vulnerabilities privately through GitHub's
+[private vulnerability reporting](https://github.com/bmir-radx/radx-data-dictionary-specification/security/advisories/new)
+(the **Security** tab → **Report a vulnerability**), or by email to
+**horridge@stanford.edu**.
+
+Please include enough detail to reproduce the issue — the affected package,
+version or commit, and a minimal example. We will acknowledge your report and
+keep you informed as we investigate and fix it.
+
+## Scope
+
+These packages parse data-dictionary files (CSV, LinkML YAML, REDCap exports)
+and render output (HTML, JSON). Reports of parser crashes, unsafe deserialization,
+resource-exhaustion on crafted input, or unsafe output rendering (e.g. HTML
+injection via the printer) are all in scope.
+
+## Supported versions
+
+This project releases from `main`; fixes are applied there and published as a
+new release. Please upgrade to the latest release before reporting, and pin to a
+released tag in production.

--- a/printer/dd_printer/render_html.py
+++ b/printer/dd_printer/render_html.py
@@ -10,10 +10,14 @@ from .markdown import render_description
 from .model import Dictionary
 from .precondition import render_precondition
 
-_TEMPLATE = files("dd_printer.templates").joinpath("dictionary.html.j2").read_text(
-    encoding="utf-8"
+# Resolve resources relative to the dd_printer package itself, not to the
+# templates/static subdirectories: those have no __init__.py, and on Python 3.9
+# importlib.resources.files() cannot resolve such a non-package subdirectory
+# (it raises TypeError). The parent package always has a concrete location.
+_TEMPLATE = (
+    files("dd_printer").joinpath("templates", "dictionary.html.j2").read_text(encoding="utf-8")
 )
-_CSS = files("dd_printer.static").joinpath("dictionary.css").read_text(encoding="utf-8")
+_CSS = files("dd_printer").joinpath("static", "dictionary.css").read_text(encoding="utf-8")
 
 # The template injects pre-rendered HTML via `| safe`, so autoescape is on for
 # everything else (labels, ids, cell values) to prevent accidental HTML/markup.

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,15 @@
+# Lint/format config shared by every package in this repo. Kept at the root so
+# `ruff check` (locally and in CI) applies the same rules everywhere.
+
+line-length = 100
+target-version = "py39"
+
+[lint]
+# F  pyflakes            E/W  pycodestyle      B  flake8-bugbear
+# C4 comprehensions      UP   pyupgrade        SIM  flake8-simplify
+# I  import sorting
+select = ["F", "E", "W", "B", "C4", "UP", "SIM", "I"]
+
+[lint.per-file-ignores]
+# Test files may use assert-heavy, less-DRY patterns.
+"**/tests/**" = ["SIM"]


### PR DESCRIPTION
Makes the repo ready for outside contributors and users. Mostly docs/CI/meta, **plus one real bug fix** that the new CI caught.

## What's here

**Trust & safety (the real gap)**
- **`ci.yml`** — lint (ruff) + tests (pytest) for all six packages on Python 3.9 and 3.12, on every push and PR. Runs *before* the release workflow, so a broken change can no longer be released. Installs the third-party deps explicitly, then each package from the **local checkout** with `--no-deps`, so a PR is tested against the code under review — not the released build pinned in the `dd-* @ git+...` URLs.
- **`ruff.toml`** — pins the shared lint ruleset (`F,E,W,B,C4,UP,SIM,I` @ 100 cols) that was previously applied only ad-hoc.

**Bug fix caught by CI**
- **`dd-print` was completely broken on Python 3.9**: `render_html.py` loaded its template/CSS via `importlib.resources.files("dd_printer.templates")`, but that subdir has no `__init__.py` and 3.9's `files()` raises `TypeError` on a non-package subdir at import time. Resolved relative to the `dd_printer` package instead. (3.10+ masked it.) This is why the PR now cuts a patch release rather than `release:skip`.

**Contribution**
- **`CONTRIBUTING.md`** — dev setup, the exact CI checks, conventions, and the label-driven release convention.
- **`.github/ISSUE_TEMPLATE/`** (bug + feature forms, config) and **`PULL_REQUEST_TEMPLATE.md`** with a release-label reminder.

**Citation & health**
- **`CITATION.cff`**, **`SECURITY.md`**, **`CODE_OF_CONDUCT.md`** (Contributor Covenant 2.1), and README CI/license/Python badges.

## Verified
- CI is **green on this PR**: `lint`, `test (3.9)`, `test (3.12)` all pass (361 tests across the six packages).
- The two earlier red runs were real problems this PR fixed: (1) pass-2 install refetching siblings from git → "import file mismatch"; (2) the dd-print 3.9 resource bug above.

## Notes
- The redirect stub `radx-data-dictionary-specification.md` was left in place (keeps old external links resolving).
- `CITATION.cff` lists Matthew Horridge / Stanford BMIR; add co-authors or an ORCID if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)