### PR TITLE
Fix release workflow: push bump via deploy key (unblock releases)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,12 @@ name: Release
 # The version bump is the essential part: pipx only reinstalls a git-installed
 # package when its version changes, so bumping is what makes `pipx upgrade` work.
 #
-# The bump commit is pushed with the default GITHUB_TOKEN, whose pushes do not
-# trigger workflows, so this cannot re-trigger itself; the actor guard below is
-# a belt-and-braces second line.
+# main is protected by a repository ruleset (pull_request required) whose only
+# permitted bypass actor is a deploy key. So the bump commit is pushed over SSH
+# with a deploy key (RELEASE_DEPLOY_KEY); a plain GITHUB_TOKEN push is rejected
+# with "Changes must be made through a pull request". Unlike a GITHUB_TOKEN
+# push, a deploy-key push DOES re-trigger this workflow, so loop prevention is
+# essential: the guard below skips the run when HEAD is itself a bump commit.
 
 on:
   push:
@@ -23,12 +26,17 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.actor != 'github-actions[bot]'
+    # Loop guard: the deploy-key push retriggers this workflow, so skip the run
+    # when this push is itself a version-bump commit.
+    if: "!startsWith(github.event.head_commit.message, 'chore: bump version to')"
     steps:
       - name: Check out code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Check out over SSH with the deploy key so the later push is
+          # authenticated as the deploy key (the ruleset's only bypass actor).
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
**The release mechanism is currently broken** and this unblocks it.

## What happened
PR #40's merge triggered the release workflow, which failed at the push step:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
 ! [remote rejected] main -> main (push declined due to repository rule violations)
```

v0.0.2 and v0.0.3 succeeded earlier only because they ran *before* the "Protect main" ruleset was fully configured. The ruleset now requires PRs and its **only** bypass actor is a **deploy key** — so the workflow's default `GITHUB_TOKEN` push is rejected, and no release is cut.

## Fix
- Check out over SSH with a **deploy key** (`RELEASE_DEPLOY_KEY` secret; a matching write deploy key is registered on the repo and is the ruleset's bypass actor). `actions/checkout`'s `ssh-key` makes the subsequent `git push` authenticate as that key.
- A deploy-key push **retriggers** the workflow (a `GITHUB_TOKEN` push doesn't), so the actor guard is replaced with a **commit-message loop guard** that skips runs whose HEAD is a `chore: bump version to …` commit.

Labelled `release:skip` (workflow-only; and we don't want to lean on the very mechanism we're repairing).

## After merge
This merge is `release:skip`, so it won't cut a release itself. The *next* normal PR merge will exercise the fixed path and should produce the first post-protection release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)