### PR TITLE
Push release branch and tag atomically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,9 +75,13 @@ jobs:
           git add '*/pyproject.toml'
           git commit -m "chore: bump version to ${V}"
           git tag "v${V}"
-          # Push branch and tag explicitly: --follow-tags only pushes annotated
-          # tags and would skip this lightweight one.
-          git push origin main "v${V}"
+          # Push branch and tag together, atomically: --follow-tags only pushes
+          # annotated tags and would skip this lightweight one, and a plain
+          # multi-ref push is NOT atomic — if the main push is rejected (e.g. by
+          # a branch ruleset) the tag can still land, orphaning a vX.Y.Z tag
+          # with no branch commit or release. --atomic makes both refs succeed
+          # or both fail.
+          git push --atomic origin main "v${V}"
 
       - name: Create GitHub release
         if: steps.level.outputs.level != 'skip'


### PR DESCRIPTION
Follow-up hardening to the release workflow.

When PR #40's release run hit the protected `main`, `git push origin main "v${V}"` pushed the two refs **non-atomically**: `main` was rejected by the ruleset but the **tag still landed**, orphaning a `v0.0.4` tag on a bump commit that never reached `main` (already cleaned up).

`git push --atomic origin main "v${V}"` makes both refs succeed or fail together, so a rejected branch push can never orphan a tag again.

`release:skip` — workflow-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)