### PR TITLE
Fix version-pin example in README to a real tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,9 @@ pipx upgrade dd-api        # (or dd-print, dd-validate, dd-redcap, dd-to-linkml�
 
 The `pip`/`pipx` install commands above track `main` (always the newest
 release). To pin to a specific release instead, append the tag to the URL,
-e.g. `…radx-data-dictionary-specification.git@v0.3.0#subdirectory=api`.
+e.g. `…radx-data-dictionary-specification.git@v0.0.3#subdirectory=api`
+(see the [releases](https://github.com/bmir-radx/radx-data-dictionary-specification/releases)
+for available tags).
 
 ## License
 


### PR DESCRIPTION
The "pin to a specific release" example pointed at `@v0.3.0`, which has never existed (latest tag is `v0.0.3`). Anyone copying it would hit a git *revision-not-found* error. Corrected to `v0.0.3` and linked the releases page for the current tag list.

Left **unlabelled on purpose**: this is the first real (non-`release:skip`) merge since the release workflow was switched to push via the deploy key (#41) with an atomic push (#42). Merging it exercises that path end-to-end and should cut **v0.0.4** with a matching GitHub release — the live confirmation the mechanism works past the protected-`main` ruleset. A docs fix warrants the default patch bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)