### PR TITLE
dd-to-linkml: --enums-last emits enums after classes

### DIFF
--- a/linkml/README.md
+++ b/linkml/README.md
@@ -90,6 +90,7 @@ BIOPORTAL_API_KEY=… dd-to-linkml my_dictionary.csv -o out.yaml \
 | Option | Effect |
 | --- | --- |
 | `--annotate-enum-values` | After a field enum's `range:`, add a comment listing its `value=label` pairs. |
+| `--enums-last` | Emit `enums` after `classes`, so the boilerplate `StandardMissingValueCodes` enum ends the document instead of preceding the data elements. |
 | `--allow-duplicates` | Tolerate a repeated `Id` (keep the first, skip later ones) instead of failing. |
 | `-v`, `--verbose` | Show warnings (unresolved term lookups, non-OBO prefixes, skipped duplicates). |
 

--- a/linkml/dd_linkml/cli.py
+++ b/linkml/dd_linkml/cli.py
@@ -113,6 +113,13 @@ def _build_parser() -> argparse.ArgumentParser:
         'enumeration cell, `"code"=[label] | ...`). An empty file omits them.',
     )
     parser.add_argument(
+        "--enums-last",
+        action="store_true",
+        help="Emit the enums section after classes, so the shared "
+        "StandardMissingValueCodes enum lands at the end of the document "
+        "instead of ahead of the data elements.",
+    )
+    parser.add_argument(
         "--allow-duplicates",
         action="store_true",
         help="Do not fail on a duplicate Id; keep the first occurrence, skip "
@@ -146,6 +153,7 @@ def _resolve_options(args: argparse.Namespace) -> EmitOptions:
         bioportal_apikey=apikey,
         annotate_enum_values=args.annotate_enum_values,
         missing_value_codes=missing_codes,
+        enums_last=args.enums_last,
     )
 
 

--- a/linkml/dd_linkml/emit.py
+++ b/linkml/dd_linkml/emit.py
@@ -172,6 +172,12 @@ class EmitOptions:
     # the built-in default set; an empty list omits the shared enum entirely; a
     # custom list replaces the default.
     missing_value_codes: list | None = None
+    # Emit the enums section after classes. YAML has one `enums` mapping, so the
+    # boilerplate StandardMissingValueCodes enum (always last within enums) can
+    # only land at the end of the document by moving the whole section there —
+    # useful for interactive previews, where a small dictionary's rendering
+    # would otherwise be dominated by the standard codes.
+    enums_last: bool = False
 
 
 class Emitter:
@@ -632,6 +638,8 @@ class Emitter:
         _drop_redundant_keys(as_dict)
         _order_slot_keys(as_dict)
         _annotations_last(as_dict)
+        if self.opts.enums_last and "enums" in as_dict:
+            as_dict["enums"] = as_dict.pop("enums")  # move to the end
         text = _render(as_dict)
         if self.opts.annotate_terms and self._terms:
             from dd_core.terms_lookup import lookup_labels

--- a/linkml/tests/test_emit.py
+++ b/linkml/tests/test_emit.py
@@ -201,6 +201,22 @@ def test_missing_value_codes_empty_omits_shared_enum():
     assert ranges == ["QEnum"]  # only the field enum, no shared missing-codes branch
 
 
+def test_enums_last_moves_enums_after_classes():
+    text = emit_schema(
+        read_data_dictionary(_csv(_ENUM_CSV)),
+        EmitOptions(schema_name="s", class_name="Record", enums_last=True),
+    )
+    assert text.index("classes:") < text.index("enums:")
+    # The shared codes enum stays last within enums — i.e. ends the document.
+    assert text.index("enums:") < text.index("StandardMissingValueCodes:")
+    assert yaml.safe_load(text)["classes"]["Record"] is not None  # still valid YAML
+
+
+def test_enums_default_order_keeps_enums_before_classes():
+    text = emit_schema(read_data_dictionary(_csv(_ENUM_CSV)))
+    assert text.index("enums:") < text.index("classes:")
+
+
 def test_parse_missing_value_codes_file(tmp_path):
     from dd_core import parse_missing_value_codes_file
 


### PR DESCRIPTION
## What

Adds an `enums_last` option to `EmitOptions` (CLI: `--enums-last`) that emits the `enums` section **after** `classes`.

## Why

In a small dictionary's rendering — e.g. dd-edit's single-field preview — the shared `StandardMissingValueCodes` enum dominates the document, sitting between the header and the data elements. YAML permits only one `enums` mapping, so placing the standard codes at the very end of the document means moving the whole section after `classes`; the standard enum is already ordered last *within* `enums`, so with this option it ends the document.

Off by default — published schemas keep their current shape. dd-edit's sidecar opts in (feature-detected, activates on its next toolkit pin bump).

## Testing

`linkml` package tests pass (75 passed, 2 skipped), including two new tests covering the reordering and the unchanged default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)