### PR TITLE
Reader/API: keep_duplicates loads duplicate-Id rows instead of failing

### DIFF
--- a/api/dd_api/model.py
+++ b/api/dd_api/model.py
@@ -261,17 +261,27 @@ class DataDictionary:
     every element that iteration yields.
     """
 
-    def __init__(self, elements: Sequence[DataElement]):
+    def __init__(
+        self, elements: Sequence[DataElement], *, allow_duplicate_ids: bool = False
+    ):
         """Build a dictionary from elements directly.
 
         Ids must be unique — a duplicate raises :class:`ValueError`. (This is
         the backstop for every constructor; :meth:`load` additionally rejects
         duplicates while reading, with the line numbers in its message.)
+
+        With ``allow_duplicate_ids``, duplicates are represented instead of
+        rejected: every element stays in the sequence (iteration, ``len``,
+        serialisation see them all) and the id index maps each id to its
+        *first* occurrence. For editors and validators, which must be able to
+        hold an invalid-but-well-formed document while the user fixes it.
         """
         self._elements = tuple(elements)
         self._by_id: dict[str, DataElement] = {}
         for element in self._elements:
             if element.id in self._by_id:
+                if allow_duplicate_ids:
+                    continue  # keep the element; the index keeps the first
                 raise ValueError(f"duplicate data element id {element.id!r}")
             self._by_id[element.id] = element
 
@@ -283,6 +293,7 @@ class DataDictionary:
         source: str | Path | TextIO,
         *,
         allow_duplicates: bool = False,
+        keep_duplicates: bool = False,
     ) -> DataDictionary:
         """Load a data dictionary from a CSV file.
 
@@ -318,12 +329,28 @@ class DataDictionary:
 
         When ``allow_duplicates`` is true, rows repeating an earlier ``Id``
         are skipped (with a logged warning) instead of raising — useful for
-        exploring an imperfect dictionary you did not author.
+        exploring an imperfect dictionary you did not author. When
+        ``keep_duplicates`` is true, duplicate rows are loaded as-is (nothing
+        skipped) — for editors, where silently dropping a row the user needs
+        to see and fix would lose data. ``keep_duplicates`` wins over
+        ``allow_duplicates`` when both are set.
         """
-        return cls.from_rows(read_data_dictionary(source, allow_duplicates=allow_duplicates))
+        return cls.from_rows(
+            read_data_dictionary(
+                source,
+                allow_duplicates=allow_duplicates,
+                keep_duplicates=keep_duplicates,
+            ),
+            allow_duplicate_ids=keep_duplicates,
+        )
 
     @classmethod
-    def from_rows(cls, rows: Sequence[Row | Mapping[str, str]]) -> DataDictionary:
+    def from_rows(
+        cls,
+        rows: Sequence[Row | Mapping[str, str]],
+        *,
+        allow_duplicate_ids: bool = False,
+    ) -> DataDictionary:
         """Build a dictionary from rows you already have in memory.
 
         This is the lower-level way in, for when the rows did not come from a
@@ -350,7 +377,10 @@ class DataDictionary:
             row if isinstance(row, Row) else Row(cells=dict(row), line=index + 2)
             for index, row in enumerate(rows)
         ]
-        return cls([_element_from_row(row) for row in normalised])
+        return cls(
+            [_element_from_row(row) for row in normalised],
+            allow_duplicate_ids=allow_duplicate_ids,
+        )
 
     @classmethod
     def from_linkml(cls, source: str | Path | TextIO | dict) -> DataDictionary:
@@ -597,14 +627,17 @@ class DataDictionary:
         return json.dumps(payload, indent=indent, ensure_ascii=False)
 
     @classmethod
-    def from_json(cls, source: str | bytes | dict) -> DataDictionary:
+    def from_json(
+        cls, source: str | bytes | dict, *, allow_duplicate_ids: bool = False
+    ) -> DataDictionary:
         """Reconstruct a dictionary from :meth:`to_json` output.
 
         ``source`` may be a JSON string/bytes or an already-parsed ``dict``.
         Element objects are turned back into typed :class:`DataElement`\\ s and
         validated exactly as :meth:`from_rows` validates rows (unknown
         datatype, malformed precondition, etc. raise
-        :class:`~dd_core.reader.ReadError`).
+        :class:`~dd_core.reader.ReadError`). ``allow_duplicate_ids`` is for
+        documents held by an editor mid-fix; see :meth:`from_rows`.
 
         ::
 
@@ -627,7 +660,8 @@ class DataDictionary:
                 f"(this build reads version {_JSON_VERSION})"
             )
         return cls.from_rows(
-            [_element_cells_from_json(obj) for obj in payload.get("elements", [])]
+            [_element_cells_from_json(obj) for obj in payload.get("elements", [])],
+            allow_duplicate_ids=allow_duplicate_ids,
         )
 
 

--- a/api/tests/test_model.py
+++ b/api/tests/test_model.py
@@ -129,6 +129,19 @@ def test_duplicate_id_raises_unless_allowed():
     assert dd.ids == ("a",)
 
 
+def test_keep_duplicates_loads_every_row():
+    # Editor mode: an invalid-but-well-formed document loads whole, so the
+    # user can see and fix the duplicates; the id index maps to the first.
+    text = "Id,Label,Datatype\na,A,string\nb,B,integer\na,A2,integer\n"
+    dd = _load(text, keep_duplicates=True)
+    assert [e.id for e in dd.elements] == ["a", "b", "a"]
+    assert dd["a"].label == "A"  # index: first occurrence
+    # Round-trips keep all rows, and dd-json reloads with the same opt-in.
+    assert dd.to_csv().count("\na,") == 2
+    reloaded = DataDictionary.from_json(dd.to_json(), allow_duplicate_ids=True)
+    assert [e.id for e in reloaded.elements] == ["a", "b", "a"]
+
+
 # --- collection protocol -----------------------------------------------------
 
 def test_collection_protocol():

--- a/core/dd_core/reader.py
+++ b/core/dd_core/reader.py
@@ -92,6 +92,7 @@ def read_data_dictionary(
     source: str | Path | TextIO,
     *,
     allow_duplicates: bool = False,
+    keep_duplicates: bool = False,
 ) -> list[Row]:
     """Read a data dictionary CSV and return its rows in order.
 
@@ -100,15 +101,20 @@ def read_data_dictionary(
     Raises :class:`ReadError` on a malformed header, a blank required cell, or a
     duplicate ``Id``. When ``allow_duplicates`` is true, a duplicate ``Id`` is
     not fatal: the first occurrence is kept, later occurrences are skipped, and
-    a warning is logged for each.
+    a warning is logged for each. When ``keep_duplicates`` is true, duplicate
+    rows are kept as-is (warning logged, nothing skipped) — for editors and
+    other tools that must not lose rows the user needs to see and fix.
+    ``keep_duplicates`` wins when both flags are set.
     """
     if isinstance(source, (str, Path)):
         with open(source, encoding="utf-8-sig", newline="") as handle:
-            return _read(handle, allow_duplicates)
-    return _read(source, allow_duplicates)
+            return _read(handle, allow_duplicates, keep_duplicates)
+    return _read(source, allow_duplicates, keep_duplicates)
 
 
-def _read(handle: TextIO, allow_duplicates: bool = False) -> list[Row]:
+def _read(
+    handle: TextIO, allow_duplicates: bool = False, keep_duplicates: bool = False
+) -> list[Row]:
     reader = csv.reader(handle)  # RFC 4180 defaults: comma, double-quote
     try:
         header = next(reader)
@@ -144,7 +150,15 @@ def _read(handle: TextIO, allow_duplicates: bool = False) -> list[Row]:
 
         row_id = cells["Id"].strip()
         if row_id in seen_ids:
-            if allow_duplicates:
+            if keep_duplicates:
+                logger.warning(
+                    "Line %d: duplicate Id %r (first seen on line %d); keeping "
+                    "both occurrences.",
+                    line,
+                    row_id,
+                    seen_ids[row_id],
+                )
+            elif allow_duplicates:
                 logger.warning(
                     "Line %d: duplicate Id %r (first seen on line %d); skipping "
                     "this occurrence.",
@@ -153,11 +167,13 @@ def _read(handle: TextIO, allow_duplicates: bool = False) -> list[Row]:
                     seen_ids[row_id],
                 )
                 continue
-            raise ReadError(
-                f"Line {line}: duplicate Id {row_id!r} "
-                f"(first seen on line {seen_ids[row_id]})."
-            )
-        seen_ids[row_id] = line
+            else:
+                raise ReadError(
+                    f"Line {line}: duplicate Id {row_id!r} "
+                    f"(first seen on line {seen_ids[row_id]})."
+                )
+        else:
+            seen_ids[row_id] = line
 
         rows.append(Row(cells=cells, line=line, extra_columns=extra_columns))
 

--- a/core/tests/test_reader.py
+++ b/core/tests/test_reader.py
@@ -98,6 +98,31 @@ def test_allow_duplicates_keeps_first_skips_rest():
     assert rows[0].get("Label") == "First A"
 
 
+def test_keep_duplicates_keeps_every_row():
+    rows = read_data_dictionary(
+        io.StringIO(
+            "Id,Label,Datatype\n"
+            "A,First A,string\n"
+            "B,Label B,integer\n"
+            "A,Second A,integer\n"
+        ),
+        keep_duplicates=True,
+    )
+    # Nothing skipped: editors must not lose the rows the user needs to fix.
+    assert [r.id for r in rows] == ["A", "B", "A"]
+    assert rows[2].get("Label") == "Second A"
+    assert rows[2].line == 4
+
+
+def test_keep_duplicates_wins_over_allow_duplicates():
+    rows = read_data_dictionary(
+        io.StringIO("Id,Label,Datatype\nA,x,string\nA,y,integer\n"),
+        allow_duplicates=True,
+        keep_duplicates=True,
+    )
+    assert [r.id for r in rows] == ["A", "A"]
+
+
 def test_duplicate_header_raises():
     with pytest.raises(ReadError, match="Duplicate column header"):
         _read_str("Id,Label,Datatype,Label\nA,x,string,y\n")


### PR DESCRIPTION
## What

- `read_data_dictionary(keep_duplicates=True)`: duplicate-Id rows are kept (warning logged), not skipped or fatal. `keep_duplicates` wins over `allow_duplicates`.
- `DataDictionary(..., allow_duplicate_ids=True)` (and `from_rows` / `from_json` / `load` passthroughs): the element sequence keeps every element; the id index maps each id to its first occurrence.
- Defaults everywhere are unchanged — strict loading still raises.

## Why

dd-edit could not open `rad.dd.csv` ("Line 493: duplicate Id 'protocol_id'"). An editor must be able to hold an invalid-but-well-formed document while the user fixes it: failing outright hides the problem, and skip-the-later-rows would silently delete a row on open+save. The validator already reports `duplicate-id` as an ERROR on the right lines, so with this the editor opens the file and flags the rows to fix.

## Testing

core+api suites pass (153 passed) with new tests for keep-every-row, precedence over `allow_duplicates`, first-occurrence indexing, and CSV/dd-json round-trips. Verified end-to-end that a kept-duplicates document still renders LinkML and that the validator flags `duplicate-id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)