### PR TITLE
Validator: addressable findings, suggestions, and advisory checks

### DIFF
--- a/api/dd_api/model.py
+++ b/api/dd_api/model.py
@@ -50,7 +50,7 @@ from __future__ import annotations
 
 import io
 import json
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Collection, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal, TextIO
@@ -590,6 +590,39 @@ class DataDictionary:
             for index, element in enumerate(self._elements)
         ]
         return emit_schema(rows, options)
+
+    def validate(self, *, ignore: Collection[str] = ()):
+        """Run the validator over this dictionary and return its findings.
+
+        The programmatic equivalent of ``dd-validate``: the dictionary is
+        serialised to its canonical CSV and every check runs against it.
+        Each returned ``dd_validator.Finding`` carries the format-independent
+        address — ``element_index`` (0-based position in document order,
+        stable across CSV, dd-json, and LinkML renderings) and
+        ``element_id`` — alongside the CSV ``line``, plus a machine-usable
+        ``suggestion`` where the check has one. ``ignore`` drops findings by
+        check name (e.g. ``{"missing-unit"}``).
+
+        Requires the sibling ``dd-validate`` package::
+
+            >>> import io
+            >>> from dd_api import DataDictionary
+            >>> dd = DataDictionary.load(io.StringIO(
+            ...     "Id,Label,Datatype\\n"
+            ...     "my field,Age,integer\\n"
+            ... ))
+            >>> finding = [f for f in dd.validate() if f.check == "id-characters"][0]
+            >>> (finding.element_index, finding.element_id, finding.suggestion)
+            (0, 'my field', 'my_field')
+        """
+        try:
+            from dd_validator.validate import validate as _validate
+        except ImportError as exc:  # pragma: no cover - environment-specific
+            raise RuntimeError(
+                "DataDictionary.validate() needs the dd-validate package "
+                "(pip install it from this repository's validator/ folder)"
+            ) from exc
+        return _validate(io.StringIO(self.to_csv()), ignore=ignore)
 
     def to_json(self, *, indent: int | None = 2, compact: bool = False) -> str:
         """Serialise this dictionary as canonical JSON, for use over an API.

--- a/core/dd_core/__init__.py
+++ b/core/dd_core/__init__.py
@@ -25,6 +25,7 @@ from .missing_values import (
     STANDARD_MISSING_VALUE_CODES_TEXT,
     parse_missing_value_codes_file,
 )
+from .naming import sanitize_identifier
 from .reader import (
     KNOWN_COLUMNS,
     REQUIRED_COLUMNS,
@@ -55,4 +56,5 @@ __all__ = [
     "ReadError",
     "Row",
     "read_data_dictionary",
+    "sanitize_identifier",
 ]

--- a/core/dd_core/naming.py
+++ b/core/dd_core/naming.py
@@ -1,0 +1,27 @@
+"""Identifier hygiene shared by the tools.
+
+The specification imposes no restrictions on ``Id`` values (spaces and any
+characters are legal), but tools that must produce schema-safe names — the
+LinkML emitter, and the validator when it explains what a rename would look
+like — share this one sanitisation rule so they can never disagree.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def sanitize_identifier(name: str) -> str:
+    """Turn an arbitrary Id/Section into a schema-safe name.
+
+    Non-word characters become underscores (collapsed), leading/trailing
+    underscores are stripped, and a leading digit is prefixed. The original
+    value is preserved elsewhere (slot title / ``original_id`` annotation),
+    so this only affects the schema-internal name.
+    """
+    safe = re.sub(r"\W+", "_", name.strip()).strip("_")
+    if not safe:
+        safe = "_"
+    if safe[0].isdigit():
+        safe = f"x_{safe}"
+    return safe

--- a/linkml/dd_linkml/emit.py
+++ b/linkml/dd_linkml/emit.py
@@ -32,6 +32,7 @@ from dd_core.missing_values import (
     STANDARD_ENUM_NAME,
     STANDARD_MISSING_VALUE_CODES,
 )
+from dd_core.naming import sanitize_identifier
 from dd_core.reader import Row
 from dd_core.units import lookup_unit
 from linkml_runtime.dumpers import json_dumper
@@ -92,19 +93,9 @@ def _represent_str(dumper: yaml.SafeDumper, data: str):
 _BlockStyleDumper.add_representer(str, _represent_str)
 
 
-def _sanitize(name: str) -> str:
-    """Turn an arbitrary Id/Section into a LinkML-safe name.
-
-    Non-word characters become underscores; a leading digit is prefixed. The
-    original value is preserved elsewhere (slot title / annotation), so this only
-    affects the schema-internal name.
-    """
-    safe = re.sub(r"\W+", "_", name.strip()).strip("_")
-    if not safe:
-        safe = "_"
-    if safe[0].isdigit():
-        safe = f"x_{safe}"
-    return safe
+# The sanitisation rule lives in dd_core (dd_core.naming) so the validator's
+# id-characters check and this emitter can never disagree about the rename.
+_sanitize = sanitize_identifier
 
 
 def _class_case(name: str) -> str:

--- a/validator/README.md
+++ b/validator/README.md
@@ -18,7 +18,8 @@ Each finding has a severity:
 | Required headers | ERROR | A required column (`Id`, `Label`, `Datatype`) is missing. |
 | Id present | ERROR | An `Id` cell is blank. |
 | Id leading whitespace | ERROR | An `Id` starts with a space. |
-| Id whitespace | INFO | An `Id` contains a space. |
+| Id characters | INFO | An `Id` contains spaces or special characters — legal, but schema renderings rename it and preconditions can't reference it (suggests the schema-safe spelling). |
+| Cell whitespace | WARNING | A cell has leading or trailing whitespace (suggests the stripped value). |
 | Label present | WARNING | A `Label` cell is blank. |
 | Datatype present | ERROR | A `Datatype` cell is blank. |
 | Unknown datatype | ERROR | A `Datatype` name is not recognised (suggests a fix). |
@@ -30,6 +31,9 @@ Each finding has a severity:
 | Duplicate Id | ERROR | An `Id` appears on more than one row. |
 | Precondition | ERROR | A `Precondition` cell does not parse, references an unknown field, orders an unordered datatype, or uses `contains` on a single-valued field. |
 | Required | ERROR | A `Required` value is not `y` or blank. |
+| Preferred datatype | INFO | A `Datatype` names a storage width (`int`, `short`, `token`) or an extension date format (`date_mdy`, `timestamp`) where the semantic builtin is usually meant (suggests it). |
+| Missing unit | INFO | A numeric, non-enumerated field has no `Unit` (counts and scores are legitimately unitless — see `--ignore`). |
+| Enumeration datatype | INFO | Every enumeration value is an integer but the `Datatype` is not (suggests `integer`). |
 
 The datatype names, the enumeration grammar, and the missing-value-codes grammar
 are reused from the sibling [converter](../converter/), so the validator stays in
@@ -65,9 +69,20 @@ dd-validate ./dictionaries/
 # Only show errors, ignoring warnings and info
 dd-validate my_dictionary.csv --levels ERROR
 
+# Drop specific advisory checks a pipeline disagrees with
+dd-validate my_dictionary.csv --ignore missing-unit datatype-preferred
+
 # Machine-readable output
 dd-validate my_dictionary.csv -f json -o report.json
 ```
+
+Each finding carries a **format-independent address** alongside the CSV line
+number: `elementIndex` (the element's 0-based position in document order,
+stable across the CSV, dd-json, and LinkML renderings of the same dictionary)
+and `elementId`. Checks with a mechanical fix also carry a `suggestion` (the
+schema-safe Id spelling, the stripped cell value, the semantic datatype name).
+Programmatic access without touching CSV text goes through the API:
+`DataDictionary.validate()` in the sibling [`dd_api`](../api/) package.
 
 Options:
 

--- a/validator/dd_validator/checks.py
+++ b/validator/dd_validator/checks.py
@@ -27,6 +27,7 @@ from dd_core import (
     REQUIRED_COLUMNS,
     UnknownDatatypeError,
     resolve_datatype,
+    sanitize_identifier,
 )
 from dd_core.grammar import (
     Comparison,
@@ -106,10 +107,19 @@ def check_id(rows: Iterable[RawRow], columns_present: set[str]) -> Iterable[Find
                 Level.ERROR, "id-leading-whitespace",
                 "Id starts with whitespace", line=row.line, column="Id", value=id_cell,
             )
-        if " " in id_cell:
+        # Spaces and special characters are legal per the specification, but
+        # they degrade the id elsewhere: schema renderings rename it (the
+        # shared sanitisation rule) and preconditions cannot reference it.
+        # Broadens the earlier id-whitespace check; the suggestion is exactly
+        # the name a schema rendering would use.
+        safe = sanitize_identifier(id_cell)
+        if safe != id_cell:
             yield Finding(
-                Level.INFO, "id-whitespace",
-                "Id contains whitespace", line=row.line, column="Id", value=id_cell,
+                Level.INFO, "id-characters",
+                f"Id contains spaces or special characters; schema renderings "
+                f"rename it to {safe!r} and preconditions cannot reference it "
+                f"as written",
+                line=row.line, column="Id", value=id_cell, suggestion=safe,
             )
 
 
@@ -196,6 +206,137 @@ def check_enumeration(rows: Iterable[RawRow], columns_present: set[str]) -> Iter
                 f"enumeration is malformed: {exc}",
                 line=row.line, column="Enumeration", value=enumeration,
             )
+
+
+def check_cell_whitespace(
+    rows: Iterable[RawRow], columns_present: set[str]
+) -> Iterable[Finding]:
+    """Leading/trailing whitespace in a cell (WARNING).
+
+    Padding survives serialisation and breaks exact-value matching — an
+    enumeration code ``' 1'`` is not ``'1'``. The suggestion is the stripped
+    value. ``Id`` is covered by its own checks (leading whitespace is an
+    ERROR there); wholly-blank cells are the missing-value checks' business.
+    """
+    for row in rows:
+        for column, cell in row.cells.items():
+            if column == "Id" or cell == "":
+                continue
+            stripped = cell.strip()
+            if stripped == cell or stripped == "":
+                continue
+            yield Finding(
+                Level.WARNING, "cell-whitespace",
+                f"{column} has leading or trailing whitespace",
+                line=row.line, column=column, value=cell, suggestion=stripped,
+            )
+
+
+# Datatype names with a preferred semantic equivalent: the storage-width /
+# lexical aliases of the builtins (int, short, token, …), plus the extension
+# date formats with a clear native counterpart. The g*/duration/binary custom
+# types are deliberate rendering choices and stay unflagged.
+_PREFERRED_DATATYPE: dict[str, str] = {
+    **{
+        name: range_
+        for name, range_ in BUILTIN_RANGES.items()
+        if name != range_ and range_ in ("string", "integer")
+    },
+    "date_mdy": "date",
+    "date_dmy": "date",
+    "timestamp": "dateTime",
+}
+
+
+def check_datatype_preferred(
+    rows: Iterable[RawRow], columns_present: set[str]
+) -> Iterable[Finding]:
+    """Advisory: prefer the semantic datatype name (INFO; the value is valid).
+
+    ``int``/``short``/``token`` name a storage width or lexical class and map
+    silently onto the semantic builtin anyway; the extension date formats
+    (``date_mdy``, ``timestamp``) render as generated custom types where the
+    native ``date``/``dateTime`` is usually meant.
+    """
+    if "Datatype" not in columns_present:
+        return
+    for row in rows:
+        name = row.get("Datatype").strip()
+        preferred = _PREFERRED_DATATYPE.get(name)
+        if preferred is None:
+            continue
+        if name in CUSTOM_TYPES:
+            message = (
+                f"datatype {name!r} renders as a generated custom type; prefer "
+                f"the native {preferred!r} unless the datafile really stores "
+                f"that format"
+            )
+        else:
+            message = (
+                f"datatype {name!r} names a storage width, not a meaning; "
+                f"the semantic type is {preferred!r}"
+            )
+        yield Finding(
+            Level.INFO, "datatype-preferred", message,
+            line=row.line, column="Datatype", value=name, suggestion=preferred,
+        )
+
+
+_NUMERIC_RANGES = frozenset({"integer", "decimal", "float", "double"})
+
+
+def check_units(rows: Iterable[RawRow], columns_present: set[str]) -> Iterable[Finding]:
+    """Advisory: a numeric, non-enumerated field with no Unit (INFO).
+
+    Counts and scores are legitimately unitless (UCUM ``1``), so this is a
+    nudge rather than a warning — and exactly why it is INFO and ignorable.
+    """
+    if "Datatype" not in columns_present:
+        return
+    for row in rows:
+        if row.get("Unit").strip() != "" or row.get("Enumeration").strip() != "":
+            continue
+        if BUILTIN_RANGES.get(row.get("Datatype").strip()) not in _NUMERIC_RANGES:
+            continue
+        yield Finding(
+            Level.INFO, "missing-unit",
+            "numeric field has no Unit — a UCUM unit (or '1' for dimensionless "
+            "counts and scores) makes values interpretable",
+            line=row.line, column="Unit",
+        )
+
+
+_INTEGER_VALUE = re.compile(r"^-?\d+$")
+
+
+def check_enumeration_datatype(
+    rows: Iterable[RawRow], columns_present: set[str]
+) -> Iterable[Finding]:
+    """Advisory: every enumeration value is an integer but Datatype is not.
+
+    All-integer value sets usually mean the underlying datatype should be
+    ``integer`` (INFO, with that as the suggestion).
+    """
+    if "Enumeration" not in columns_present or "Datatype" not in columns_present:
+        return
+    for row in rows:
+        cell = row.get("Enumeration")
+        if cell.strip() == "":
+            continue
+        try:
+            items = parse_enumeration(cell)
+        except ParseError:
+            continue  # malformed-enumeration reports it
+        if not items or not all(_INTEGER_VALUE.match(item.value.strip()) for item in items):
+            continue
+        datatype = row.get("Datatype").strip()
+        if BUILTIN_RANGES.get(datatype) == "integer":
+            continue
+        yield Finding(
+            Level.INFO, "enumeration-integer-datatype",
+            f"every enumeration value is an integer but Datatype is {datatype!r}",
+            line=row.line, column="Datatype", value=datatype, suggestion="integer",
+        )
 
 
 def check_missing_value_codes(

--- a/validator/dd_validator/cli.py
+++ b/validator/dd_validator/cli.py
@@ -4,7 +4,7 @@ Usage::
 
     dd-validate INPUT [-o OUTPUT] [--format text|csv|tsv|json]
                 [--levels ERROR WARNING INFO] [--no-duplicate-check]
-                [--exit-zero]
+                [--ignore CHECK ...] [--exit-zero]
 
 INPUT may be a single CSV file or a directory (every ``*.csv`` beneath it is
 validated). Output goes to stdout unless ``-o`` is given.
@@ -49,6 +49,11 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Do not check for duplicate Ids (matches the reference validator).",
     )
     parser.add_argument(
+        "--ignore", nargs="+", metavar="CHECK", default=(),
+        help="Drop findings by check name (e.g. --ignore missing-unit "
+        "datatype-preferred), for tuning out advisory checks.",
+    )
+    parser.add_argument(
         "--exit-zero", action="store_true",
         help="Always exit 0, even when errors are found.",
     )
@@ -74,7 +79,9 @@ def main(argv=None) -> int:
     per_file_reports: list[str] = []
     all_findings: list[Finding] = []
     for path in _input_files(args.input):
-        findings = validate(path, check_duplicate_ids=not args.no_duplicate_check)
+        findings = validate(
+            path, check_duplicate_ids=not args.no_duplicate_check, ignore=args.ignore
+        )
         if levels is not None:
             findings = [finding for finding in findings if finding.level in levels]
         all_findings.extend(findings)

--- a/validator/dd_validator/model.py
+++ b/validator/dd_validator/model.py
@@ -39,9 +39,19 @@ class Finding:
     """One validation problem.
 
     ``check`` is a short stable identifier (e.g. ``"unknown-datatype"``).
-    ``line`` is the 1-based line in the source CSV, or ``None`` for a
-    whole-file / header finding. ``column`` and ``value`` locate the offending
-    cell when applicable.
+
+    A finding is addressed two ways. ``line`` is the 1-based line in the
+    source CSV — a *presentation* of location, meaningful only for the CSV
+    that was validated. ``element_index`` / ``element_id`` are the
+    format-independent address: the element's 0-based position in document
+    order (stable across CSV, dd-json, and LinkML renderings, which all
+    preserve element order) and its ``Id``. The index is canonical — ids may
+    legitimately be duplicated in a document under repair — and the id is the
+    human-readable companion. Both are ``None`` for whole-file findings.
+
+    ``column`` and ``value`` locate the offending cell when applicable, and
+    ``suggestion`` carries a machine-usable replacement value when the check
+    has one (e.g. the schema-safe spelling of an Id).
     """
 
     level: Level
@@ -50,6 +60,9 @@ class Finding:
     line: int | None = None
     column: str | None = None
     value: str | None = None
+    element_index: int | None = None
+    element_id: str | None = None
+    suggestion: str | None = None
 
     @property
     def sort_key(self) -> tuple[int, int, str]:

--- a/validator/dd_validator/report.py
+++ b/validator/dd_validator/report.py
@@ -77,6 +77,11 @@ def _render_json(findings: Sequence[Finding], file: str) -> str:
                 "line": finding.line,
                 "column": finding.column,
                 "value": finding.value,
+                # The format-independent address (document-order position and
+                # Id) and the machine-usable fix, when the check has one.
+                "elementIndex": finding.element_index,
+                "elementId": finding.element_id,
+                "suggestion": finding.suggestion,
             }
             for finding in findings
         ],

--- a/validator/dd_validator/validate.py
+++ b/validator/dd_validator/validate.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection
+from dataclasses import replace
 from pathlib import Path
 from typing import TextIO
 
@@ -14,18 +16,43 @@ def validate(
     source: str | Path | TextIO,
     *,
     check_duplicate_ids: bool = True,
+    ignore: Collection[str] = (),
 ) -> list[Finding]:
     """Validate a data dictionary CSV and return all findings, sorted.
 
     ``source`` may be a path or an open text file object. Findings are ordered
     by source line, then severity, then check name. Set ``check_duplicate_ids``
     to ``False`` to match the reference validator, which performs no cross-row
-    checks.
+    checks. ``ignore`` drops findings by check name (e.g. ``{"missing-unit"}``)
+    so a pipeline can tune out advisory checks it disagrees with.
     """
     header, rows = read_rows(source)
     findings = _run_all_checks(header, rows, check_duplicate_ids=check_duplicate_ids)
+    if ignore:
+        ignored = set(ignore)
+        findings = [f for f in findings if f.check not in ignored]
+    findings = _address_findings(findings, rows)
     findings.sort(key=lambda finding: finding.sort_key)
     return findings
+
+
+def _address_findings(findings: list[Finding], rows: list[RawRow]) -> list[Finding]:
+    """Fill each row finding's format-independent address from its line.
+
+    Checks report the CSV line they are looking at; this single pass maps the
+    line to (``element_index``, ``element_id``) — the 0-based document-order
+    position and the row's Id — so every check, present and future, becomes
+    addressable without touching its construction sites.
+    """
+    by_line = {
+        row.line: (index, row.get("Id").strip() or None) for index, row in enumerate(rows)
+    }
+    return [
+        replace(f, element_index=by_line[f.line][0], element_id=by_line[f.line][1])
+        if f.line in by_line
+        else f
+        for f in findings
+    ]
 
 
 def _run_all_checks(
@@ -45,9 +72,13 @@ def _run_all_checks(
     findings.extend(checks.check_id(rows, columns_present))
     findings.extend(checks.check_label(rows, columns_present))
     findings.extend(checks.check_datatype(rows, columns_present))
+    findings.extend(checks.check_datatype_preferred(rows, columns_present))
     findings.extend(checks.check_cardinality(rows, columns_present))
     findings.extend(checks.check_pattern(rows, columns_present))
     findings.extend(checks.check_enumeration(rows, columns_present))
+    findings.extend(checks.check_enumeration_datatype(rows, columns_present))
+    findings.extend(checks.check_units(rows, columns_present))
+    findings.extend(checks.check_cell_whitespace(rows, columns_present))
     findings.extend(checks.check_missing_value_codes(rows, columns_present))
     findings.extend(checks.check_preconditions(rows, columns_present))
     findings.extend(checks.check_required(rows, columns_present))

--- a/validator/tests/test_checks.py
+++ b/validator/tests/test_checks.py
@@ -2,15 +2,19 @@
 
 from dd_validator.checks import (
     check_cardinality,
+    check_cell_whitespace,
     check_datatype,
+    check_datatype_preferred,
     check_duplicate_ids,
     check_enumeration,
+    check_enumeration_datatype,
     check_id,
     check_label,
     check_missing_value_codes,
     check_pattern,
     check_required_headers,
     check_see_also,
+    check_units,
 )
 from dd_validator.model import Level
 from dd_validator.rows import RawRow
@@ -49,13 +53,104 @@ def test_id_missing():
 def test_id_leading_space_yields_error_and_info():
     findings = list(check_id(_rows((2, {"Id": " age"})), {"Id"}))
     checks = {f.check: f.level for f in findings}
-    assert checks == {"id-leading-whitespace": Level.ERROR, "id-whitespace": Level.INFO}
+    assert checks == {"id-leading-whitespace": Level.ERROR, "id-characters": Level.INFO}
 
 
 def test_id_interior_space_is_info_only():
     findings = list(check_id(_rows((2, {"Id": "a b"})), {"Id"}))
-    assert [f.check for f in findings] == ["id-whitespace"]
+    assert [f.check for f in findings] == ["id-characters"]
     assert findings[0].level is Level.INFO
+    assert findings[0].suggestion == "a_b"
+
+
+def test_id_special_characters_flagged_with_schema_safe_suggestion():
+    (finding,) = list(check_id(_rows((2, {"Id": "9-lives (total)"})), {"Id"}))
+    assert finding.check == "id-characters"
+    # The suggestion is exactly the emitter's rename (dd_core sanitize rule).
+    assert finding.suggestion == "x_9_lives_total"
+
+
+def test_id_clean_identifier_is_silent():
+    assert list(check_id(_rows((2, {"Id": "age_years"})), {"Id"})) == []
+
+
+# --- cell whitespace ----------------------------------------------------------
+
+def test_padded_cell_warned_with_stripped_suggestion():
+    row = {"Id": "age", "Label": " Age ", "Unit": "a"}
+    (finding,) = list(check_cell_whitespace(_rows((2, row)), {"Id", "Label", "Unit"}))
+    assert finding.check == "cell-whitespace" and finding.level is Level.WARNING
+    assert finding.column == "Label" and finding.suggestion == "Age"
+
+
+def test_cell_whitespace_skips_id_blank_and_whitespace_only_cells():
+    row = {"Id": " age", "Label": "", "Notes": "   "}
+    assert list(check_cell_whitespace(_rows((2, row)), {"Id", "Label", "Notes"})) == []
+
+
+# --- advisory: datatype-preferred -------------------------------------------
+
+def test_datatype_alias_prefers_semantic_name():
+    (finding,) = list(check_datatype_preferred(_rows((2, {"Datatype": "int"})), {"Datatype"}))
+    assert finding.check == "datatype-preferred" and finding.level is Level.INFO
+    assert finding.suggestion == "integer"
+    assert "storage width" in finding.message
+
+
+def test_datatype_extension_format_prefers_native():
+    (finding,) = list(
+        check_datatype_preferred(_rows((2, {"Datatype": "date_mdy"})), {"Datatype"})
+    )
+    assert finding.suggestion == "date"
+    assert "custom type" in finding.message
+
+
+def test_datatype_semantic_and_deliberate_custom_names_are_silent():
+    for name in ("integer", "string", "date", "dateTime", "anyURI", "gYear", "duration"):
+        assert list(check_datatype_preferred(_rows((2, {"Datatype": name})), {"Datatype"})) == []
+
+
+# --- advisory: missing-unit --------------------------------------------------
+
+def test_numeric_field_without_unit_is_nudged():
+    (finding,) = list(check_units(_rows((2, {"Datatype": "decimal"})), {"Datatype"}))
+    assert finding.check == "missing-unit" and finding.level is Level.INFO
+    assert finding.column == "Unit"
+
+
+def test_unit_present_enumerated_or_non_numeric_is_silent():
+    assert list(check_units(_rows((2, {"Datatype": "decimal", "Unit": "kg"})), {"Datatype"})) == []
+    assert (
+        list(
+            check_units(
+                _rows((2, {"Datatype": "integer", "Enumeration": '"0"=[No]'})), {"Datatype"}
+            )
+        )
+        == []
+    )
+    assert list(check_units(_rows((2, {"Datatype": "string"})), {"Datatype"})) == []
+    # timestamp is a custom type with implicit seconds — not nudged.
+    assert list(check_units(_rows((2, {"Datatype": "timestamp"})), {"Datatype"})) == []
+
+
+# --- advisory: enumeration-integer-datatype ----------------------------------
+
+def test_all_integer_enumeration_with_text_datatype_is_nudged():
+    row = {"Datatype": "string", "Enumeration": '"0"=[No] | "1"=[Yes]'}
+    (finding,) = list(check_enumeration_datatype(_rows((2, row)), {"Datatype", "Enumeration"}))
+    assert finding.check == "enumeration-integer-datatype"
+    assert finding.suggestion == "integer"
+
+
+def test_enumeration_datatype_silent_when_integerish_or_not_all_integers():
+    ok = {"Datatype": "int", "Enumeration": '"0"=[No]'}  # int maps to integer
+    assert list(check_enumeration_datatype(_rows((2, ok)), {"Datatype", "Enumeration"})) == []
+    mixed = {"Datatype": "string", "Enumeration": '"0"=[No] | "U"=[Unknown]'}
+    assert list(check_enumeration_datatype(_rows((2, mixed)), {"Datatype", "Enumeration"})) == []
+    malformed = {"Datatype": "string", "Enumeration": "1=No|2=Yes"}  # REDCap grammar
+    assert (
+        list(check_enumeration_datatype(_rows((2, malformed)), {"Datatype", "Enumeration"})) == []
+    )
 
 
 def test_id_absent_column_is_silent():

--- a/validator/tests/test_validate.py
+++ b/validator/tests/test_validate.py
@@ -6,7 +6,9 @@ from dd_validator import validate
 from dd_validator.model import Level
 from dd_validator.rows import read_rows
 
-CLEAN = "Id,Label,Datatype\nage,Age,integer\nweight,Weight,decimal\n"
+# Clean means clean under every check, the advisory ones included — the
+# numeric fields carry units, so missing-unit stays silent.
+CLEAN = "Id,Label,Datatype,Unit\nage,Age,integer,a\nweight,Weight,decimal,kg\n"
 
 
 def _validate(text, **kwargs):
@@ -52,6 +54,38 @@ def test_optional_column_absent_is_not_flagged():
     # No Cardinality/Pattern/SeeAlso columns: their checks must stay silent.
     findings = _validate(CLEAN)
     assert findings == []
+
+
+def test_findings_carry_format_independent_address():
+    text = (
+        "Id,Label,Datatype,Unit\n"
+        "age,Age,integer,a\n"
+        "bmi,,decimal,kg/m2\n"  # line 3 = element index 1: label warning
+    )
+    (finding,) = _validate(text)
+    assert finding.check == "label-missing"
+    assert finding.line == 3
+    assert (finding.element_index, finding.element_id) == (1, "bmi")
+
+
+def test_addressing_survives_blank_lines():
+    # A blank line shifts CSV line numbers but not element indexes.
+    text = "Id,Label,Datatype,Unit\nage,Age,integer,a\n\nbmi,,decimal,kg/m2\n"
+    (finding,) = _validate(text)
+    assert finding.line == 4
+    assert (finding.element_index, finding.element_id) == (1, "bmi")
+
+
+def test_whole_file_findings_have_no_element_address():
+    (finding,) = _validate("")
+    assert finding.element_index is None and finding.element_id is None
+
+
+def test_ignore_drops_findings_by_check_name():
+    text = "Id,Label,Datatype\nage,Age,integer\n"  # numeric, no Unit column
+    assert any(f.check == "missing-unit" for f in _validate(text))
+    remaining = _validate(text, ignore={"missing-unit"})
+    assert all(f.check != "missing-unit" for f in remaining)
 
 
 def test_read_rows_skips_blank_lines_and_strips_bom():


### PR DESCRIPTION
## What

**Format-independent addressing.** Every row finding now carries `element_index` (0-based position in document order) and `element_id` alongside the CSV `line`. Line numbers are a presentation of location tied to one serialization; the index is stable across the CSV, dd-json, and LinkML renderings of the same dictionary, and stays unambiguous where duplicate Ids are being repaired (#45). Filled in a single post-pass in `validate()`, so every check — present and future — is covered without touching its construction sites. Exposed in the JSON report as `elementIndex`/`elementId`.

**Machine-usable suggestions.** Checks with a mechanical fix carry `suggestion`: the schema-safe Id spelling, the stripped cell value, the semantic datatype name. Harmonization pipelines can apply these programmatically.

**New advisory checks** (one broadened):
- `id-characters` (INFO, replaces `id-whitespace`): spaces/special characters are legal per the spec, but schema renderings rename the id and preconditions can't reference it. The sanitisation rule moves to `dd_core.naming.sanitize_identifier`, shared with the LinkML emitter so the two can never disagree about the rename.
- `cell-whitespace` (WARNING): leading/trailing padding survives serialisation and breaks exact-value matching.
- `datatype-preferred` (INFO): `int`/`short`/`token` name a storage width, not a meaning; `date_mdy`/`date_dmy`/`timestamp` render as generated custom types where native `date`/`dateTime` is usually meant. The deliberate custom types (`gYear`, `duration`, …) stay unflagged.
- `missing-unit` (INFO): numeric, non-enumerated field with no `Unit` — counts and scores are legitimately unitless, hence INFO and ignorable.
- `enumeration-integer-datatype` (INFO): all-integer value set on a non-integer datatype.

**Tuning + API.** `validate(ignore={...})` / `dd-validate --ignore CHECK ...` drop findings by check name. `DataDictionary.validate()` (dd_api, soft dependency on dd-validate) gives programmatic access without touching CSV text.

## Breaking-ish

The `id-whitespace` check name is gone (broadened into `id-characters`); anything filtering by that name should switch.

## Testing

All six package suites pass (382 tests): new coverage for each check, the addressing post-pass (including blank-line offsets and whole-file findings), `--ignore`, and a doctest on `DataDictionary.validate()`.

## Follow-up

dd-edit currently synthesizes its own client-side `missing-unit` INFO findings; the pin bump to the release containing this must remove that synthesis (or every unit nudge shows twice) and can switch the grid to `elementIndex` addressing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)