### PR TITLE
format-harmonization check; corpus-informed unit curation

### DIFF
--- a/core/dd_core/ucum.py
+++ b/core/dd_core/ucum.py
@@ -72,8 +72,18 @@ UCUM_UNITS: tuple[UcumUnit, ...] = (
     UcumUnit("km", "kilometer", spellings=("kilometre", "kilometres")),
     UcumUnit("[in_i]", "inch", plural="inches", spellings=("in",)),
     UcumUnit("[ft_i]", "foot", plural="feet", spellings=("ft",)),
-    # --- volume
-    UcumUnit("L", "liter", spellings=("litre", "litres", "ltr")),
+    # --- lengths beyond the basics; areas / volumes of length (the exponent
+    # normalisation folds mm² and mm^2 onto mm2)
+    UcumUnit("um", "micrometer", spellings=("micron", "microns", "micrometre", "micrometres")),
+    UcumUnit("cm2", "square centimeter", spellings=("sq cm",)),
+    UcumUnit("mm2", "square millimeter", spellings=("sq mm",)),
+    UcumUnit("m3", "cubic meter", spellings=("cu m",)),
+    UcumUnit("cm3", "cubic centimeter", spellings=("cu cm",)),
+    UcumUnit("mm3", "cubic millimeter", spellings=("cu mm",)),
+    # --- volume ("l" is explicit and deliberate: l and L both mean liter in
+    # UCUM, so this case fix is safe — single letters generally are NOT case
+    # fixed, because a flip can change the unit: S is siemens, s is second)
+    UcumUnit("L", "liter", spellings=("l", "litre", "litres", "ltr")),
     UcumUnit("dL", "deciliter", spellings=("decilitre", "decilitres")),
     UcumUnit(
         "mL", "milliliter",
@@ -101,6 +111,9 @@ UCUM_UNITS: tuple[UcumUnit, ...] = (
     UcumUnit("[IU]/L", "international unit per liter"),
     UcumUnit("[IU]/mL", "international unit per milliliter"),
     UcumUnit("mmol/mol", "millimole per mole"),
+    UcumUnit("mg/L", "milligram per liter", spellings=("mgl",)),
+    UcumUnit("ug/L", "microgram per liter", spellings=("ugl",)),
+    UcumUnit("uS/cm", "microsiemens per centimeter", spellings=("uscm",)),
     UcumUnit("10*9/L", "billion per liter", spellings=("10^9/l", "x10^9/l")),
     UcumUnit("10*6/uL", "million per microliter"),
     UcumUnit("10*3/uL", "thousand per microliter"),
@@ -132,12 +145,15 @@ UCUM_UNITS: tuple[UcumUnit, ...] = (
     ),
     UcumUnit("kcal", "kilocalorie", spellings=("kilocalories",)),
     UcumUnit("kJ", "kilojoule", spellings=("kilojoules",)),
+    UcumUnit("kW.h", "kilowatt hour", spellings=("kwh", "kilowatt hours", "kw h")),
     # --- body / composite
     UcumUnit("kg/m2", "kilogram per square meter", spellings=("bmi",)),
     UcumUnit("m2", "square meter", spellings=("sq m", "square meters", "square metres")),
     UcumUnit("mg/kg", "milligram per kilogram"),
     # --- dimensionless
-    UcumUnit("%", "percent", spellings=("per cent", "pct", "percentage")),
+    UcumUnit("%", "percent", spellings=("per cent", "pct", "percentage", "perc")),
+    UcumUnit("[ppm]", "part per million", spellings=("ppm", "parts per million")),
+    UcumUnit("[ppb]", "part per billion", spellings=("ppb", "parts per billion")),
     UcumUnit("1", "dimensionless", spellings=("unitless", "no unit", "no units")),
 )
 
@@ -178,7 +194,14 @@ def _build_index() -> dict[str, str]:
             index[key] = code
 
     for unit in UCUM_UNITS:
-        claim(unit.code, unit.code)  # case/symbol-variant code spellings
+        # Case/symbol-variant code spellings — multi-character codes only.
+        # Single-letter case flips can silently change the unit (the corpus
+        # survey found 'S' meaning siemens, which a case fix would turn into
+        # 's', seconds; likewise A/a is ampere vs year). Exact single-letter
+        # codes still resolve; deliberate safe flips (l -> L) are explicit
+        # spellings.
+        if len(unit.code) > 1:
+            claim(unit.code, unit.code)
         claim(unit.name, unit.code)
         claim(unit.plural or _plural(unit.name) or "", unit.code)
         for spelling in unit.spellings:

--- a/core/tests/test_ucum.py
+++ b/core/tests/test_ucum.py
@@ -54,3 +54,27 @@ def test_unknown_and_valid_exotic_codes_stay_silent():
     assert suggest_ucum("nmol/L") is None  # valid UCUM, outside the subset
     assert suggest_ucum("") is None
     assert suggest_ucum("   ") is None
+
+
+def test_single_letter_case_flips_are_not_suggested():
+    # The corpus survey found 'S' meaning siemens; a case "fix" to 's'
+    # (seconds) would change the unit. Same hazard for D, A, G.
+    assert suggest_ucum("S") is None
+    assert suggest_ucum("D") is None
+    # ...but the deliberate, safe flip stays (l and L both mean liter):
+    assert suggest_ucum("l").code == "L"
+    # and exact single-letter codes still resolve.
+    assert ucum_unit("s").name == "second"
+    assert ucum_unit("A").name == "ampere"
+
+
+def test_corpus_informed_units_resolve():
+    assert suggest_ucum("ppm").code == "[ppm]"
+    assert suggest_ucum("uScm").code == "uS/cm"
+    assert suggest_ucum("mgL").code == "mg/L"
+    assert suggest_ucum("kWh").code == "kW.h"
+    assert suggest_ucum("micron").code == "um"
+    assert suggest_ucum("mm^3").code == "mm3"
+    assert suggest_ucum("perc").code == "%"
+    assert ucum_unit("mg/L") is not None  # curated: exact code, no suggestion
+    assert suggest_ucum("mg/L") is None

--- a/validator/README.md
+++ b/validator/README.md
@@ -31,7 +31,8 @@ Each finding has a severity:
 | Duplicate Id | ERROR | An `Id` appears on more than one row. |
 | Precondition | ERROR | A `Precondition` cell does not parse, references an unknown field, orders an unordered datatype, or uses `contains` on a single-valued field. |
 | Required | ERROR | A `Required` value is not `y` or blank. |
-| Preferred datatype | INFO | A `Datatype` names a storage width (`int`, `short`, `token`) or an extension date format (`date_mdy`, `timestamp`) where the semantic builtin is usually meant (suggests it). |
+| Preferred datatype | INFO | A `Datatype` names a storage width (`int`, `short`, `token`) — a free rename to the semantic builtin (suggests it). |
+| Format harmonization | INFO | A REDCap-style format (`date_mdy`, `date_dmy`, `timestamp`) — valid as-is; records the harmonized target (`date`/`dateTime`) for pipelines that migrate the datafile too. |
 | Missing unit | INFO | A numeric, non-enumerated field has no `Unit` (counts and scores are legitimately unitless — see `--ignore`). |
 | Enumeration datatype | INFO | Every enumeration value is an integer but the `Datatype` is not (suggests `integer`). |
 | Alias / Id collision | WARNING | An alias equals an element `Id`, or is claimed by two elements — either breaks datafile-header keying. |

--- a/validator/dd_validator/checks.py
+++ b/validator/dd_validator/checks.py
@@ -646,19 +646,14 @@ def check_section_runs(rows: Iterable[RawRow], columns_present: set[str]) -> Ite
         current = section
 
 
-# Datatype names with a preferred semantic equivalent: the storage-width /
-# lexical aliases of the builtins (int, short, token, …), plus the extension
-# date formats with a clear native counterpart. The g*/duration/binary custom
-# types are deliberate rendering choices and stay unflagged.
+# Datatype names that are pure aliases of a semantic builtin: renaming them
+# is free (same value space; the schema maps them silently anyway). The
+# g*/duration/binary custom types are deliberate rendering choices and stay
+# unflagged; the REDCap-style formats are format-harmonization's business.
 _PREFERRED_DATATYPE: dict[str, str] = {
-    **{
-        name: range_
-        for name, range_ in BUILTIN_RANGES.items()
-        if name != range_ and range_ in ("string", "integer")
-    },
-    "date_mdy": "date",
-    "date_dmy": "date",
-    "timestamp": "dateTime",
+    name: range_
+    for name, range_ in BUILTIN_RANGES.items()
+    if name != range_ and range_ in ("string", "integer")
 }
 
 
@@ -668,9 +663,8 @@ def check_datatype_preferred(
     """Advisory: prefer the semantic datatype name (INFO; the value is valid).
 
     ``int``/``short``/``token`` name a storage width or lexical class and map
-    silently onto the semantic builtin anyway; the extension date formats
-    (``date_mdy``, ``timestamp``) render as generated custom types where the
-    native ``date``/``dateTime`` is usually meant.
+    silently onto the semantic builtin anyway — the rename is free, so the
+    suggestion is safe to apply mechanically.
     """
     if "Datatype" not in columns_present:
         return
@@ -679,20 +673,49 @@ def check_datatype_preferred(
         preferred = _PREFERRED_DATATYPE.get(name)
         if preferred is None:
             continue
-        if name in CUSTOM_TYPES:
-            message = (
-                f"datatype {name!r} renders as a generated custom type; prefer "
-                f"the native {preferred!r} unless the datafile really stores "
-                f"that format"
-            )
-        else:
-            message = (
-                f"datatype {name!r} names a storage width, not a meaning; "
-                f"the semantic type is {preferred!r}"
-            )
         yield Finding(
-            Level.INFO, "datatype-preferred", message,
+            Level.INFO, "datatype-preferred",
+            f"datatype {name!r} names a storage width, not a meaning; "
+            f"the semantic type is {preferred!r}",
             line=row.line, column="Datatype", value=name, suggestion=preferred,
+        )
+
+
+# REDCap-style source formats and their harmonized targets. UNLIKE the pure
+# aliases above, these truthfully describe the datafile as it is (mm/dd/yyyy
+# strings, Unix seconds): changing the dictionary alone would make it lie.
+# The recommendation is to harmonize the DATA, then the datatype — so the
+# suggestion is for migration pipelines, not for one-click dictionary edits.
+_HARMONIZATION_TARGETS: dict[str, str] = {
+    "date_mdy": "date",
+    "date_dmy": "date",
+    "timestamp": "dateTime",
+}
+
+
+def check_format_harmonization(
+    rows: Iterable[RawRow], columns_present: set[str]
+) -> Iterable[Finding]:
+    """Advisory: REDCap-style formats have a harmonized end-state (INFO).
+
+    ``date_mdy``/``date_dmy``/``timestamp`` are valid and honest about the
+    source data; the finding records the recommended target (``date`` /
+    ``dateTime``) as the suggestion for pipelines that migrate the datafile
+    along with the dictionary.
+    """
+    if "Datatype" not in columns_present:
+        return
+    for row in rows:
+        name = row.get("Datatype").strip()
+        target = _HARMONIZATION_TARGETS.get(name)
+        if target is None:
+            continue
+        yield Finding(
+            Level.INFO, "format-harmonization",
+            f"datatype {name!r} describes REDCap-style source data — valid "
+            f"as-is; harmonizing the datafile (and then this field) to "
+            f"{target!r} is the recommended end-state",
+            line=row.line, column="Datatype", value=name, suggestion=target,
         )
 
 

--- a/validator/dd_validator/checks.py
+++ b/validator/dd_validator/checks.py
@@ -743,7 +743,8 @@ def check_units(rows: Iterable[RawRow], columns_present: set[str]) -> Iterable[F
         yield Finding(
             Level.INFO, "missing-unit",
             "numeric field has no Unit — a UCUM unit (or '1' for dimensionless "
-            "counts and scores) makes values interpretable",
+            "counts and scores) makes values reliably interpretable and is "
+            "supported by standards like LinkML",
             line=row.line, column="Unit",
         )
 

--- a/validator/dd_validator/checks.py
+++ b/validator/dd_validator/checks.py
@@ -686,10 +686,13 @@ def check_datatype_preferred(
 # strings, Unix seconds): changing the dictionary alone would make it lie.
 # The recommendation is to harmonize the DATA, then the datatype — so the
 # suggestion is for migration pipelines, not for one-click dictionary edits.
-_HARMONIZATION_TARGETS: dict[str, str] = {
-    "date_mdy": "date",
-    "date_dmy": "date",
-    "timestamp": "dateTime",
+# format -> (harmonized target, concrete value example). The example makes
+# "harmonize" unambiguous: it is the DATA that changes shape, not just the
+# dictionary cell.
+_HARMONIZATION_TARGETS: dict[str, tuple[str, str]] = {
+    "date_mdy": ("date", "05/27/2014 becomes 2014-05-27"),
+    "date_dmy": ("date", "27/05/2014 becomes 2014-05-27"),
+    "timestamp": ("dateTime", "1401148800 becomes 2014-05-27T00:00:00Z"),
 }
 
 
@@ -701,20 +704,22 @@ def check_format_harmonization(
     ``date_mdy``/``date_dmy``/``timestamp`` are valid and honest about the
     source data; the finding records the recommended target (``date`` /
     ``dateTime``) as the suggestion for pipelines that migrate the datafile
-    along with the dictionary.
+    along with the dictionary, and the message shows a concrete value
+    transformation so "harmonize" is unambiguous.
     """
     if "Datatype" not in columns_present:
         return
     for row in rows:
         name = row.get("Datatype").strip()
-        target = _HARMONIZATION_TARGETS.get(name)
-        if target is None:
+        entry = _HARMONIZATION_TARGETS.get(name)
+        if entry is None:
             continue
+        target, example = entry
         yield Finding(
             Level.INFO, "format-harmonization",
             f"datatype {name!r} describes REDCap-style source data — valid "
             f"as-is; harmonizing the datafile (and then this field) to "
-            f"{target!r} is the recommended end-state",
+            f"{target!r} is the recommended end-state (so {example})",
             line=row.line, column="Datatype", value=name, suggestion=target,
         )
 

--- a/validator/dd_validator/validate.py
+++ b/validator/dd_validator/validate.py
@@ -73,6 +73,7 @@ def _run_all_checks(
     findings.extend(checks.check_label(rows, columns_present))
     findings.extend(checks.check_datatype(rows, columns_present))
     findings.extend(checks.check_datatype_preferred(rows, columns_present))
+    findings.extend(checks.check_format_harmonization(rows, columns_present))
     findings.extend(checks.check_cardinality(rows, columns_present))
     findings.extend(checks.check_pattern(rows, columns_present))
     findings.extend(checks.check_enumeration(rows, columns_present))

--- a/validator/tests/test_checks.py
+++ b/validator/tests/test_checks.py
@@ -112,6 +112,8 @@ def test_redcap_formats_get_a_harmonization_target():
     assert finding.check == "format-harmonization" and finding.level is Level.INFO
     assert finding.suggestion == "date"
     assert "valid as-is" in finding.message
+    # A concrete transformation makes "harmonize" unambiguous.
+    assert "05/27/2014 becomes 2014-05-27" in finding.message
     (ts,) = list(
         check_format_harmonization(_rows((2, {"Datatype": "timestamp"})), {"Datatype"})
     )

--- a/validator/tests/test_checks.py
+++ b/validator/tests/test_checks.py
@@ -8,6 +8,7 @@ from dd_validator.checks import (
     check_duplicate_ids,
     check_enumeration,
     check_enumeration_datatype,
+    check_format_harmonization,
     check_id,
     check_label,
     check_missing_value_codes,
@@ -97,17 +98,31 @@ def test_datatype_alias_prefers_semantic_name():
     assert "storage width" in finding.message
 
 
-def test_datatype_extension_format_prefers_native():
-    (finding,) = list(
-        check_datatype_preferred(_rows((2, {"Datatype": "date_mdy"})), {"Datatype"})
-    )
-    assert finding.suggestion == "date"
-    assert "custom type" in finding.message
-
-
 def test_datatype_semantic_and_deliberate_custom_names_are_silent():
-    for name in ("integer", "string", "date", "dateTime", "anyURI", "gYear", "duration"):
+    # date_mdy et al. are format-harmonization's business, not a free rename.
+    names = ("integer", "string", "date", "dateTime", "anyURI", "gYear", "duration", "date_mdy")
+    for name in names:
         assert list(check_datatype_preferred(_rows((2, {"Datatype": name})), {"Datatype"})) == []
+
+
+def test_redcap_formats_get_a_harmonization_target():
+    (finding,) = list(
+        check_format_harmonization(_rows((2, {"Datatype": "date_mdy"})), {"Datatype"})
+    )
+    assert finding.check == "format-harmonization" and finding.level is Level.INFO
+    assert finding.suggestion == "date"
+    assert "valid as-is" in finding.message
+    (ts,) = list(
+        check_format_harmonization(_rows((2, {"Datatype": "timestamp"})), {"Datatype"})
+    )
+    assert ts.suggestion == "dateTime"
+
+
+def test_native_and_alias_datatypes_are_not_harmonization_flagged():
+    for name in ("date", "dateTime", "int", "string"):
+        assert (
+            list(check_format_harmonization(_rows((2, {"Datatype": name})), {"Datatype"})) == []
+        )
 
 
 # --- advisory: missing-unit --------------------------------------------------


### PR DESCRIPTION
Two related changes, both from today's discussion + corpus survey:

## format-harmonization (new check, split from datatype-preferred)

`date_mdy`/`date_dmy`/`timestamp` truthfully describe the datafile as it is (mm/dd/yyyy strings, Unix seconds) — a one-click dictionary rename would make the dictionary lie about the data. They move out of `datatype-preferred` (which now covers only the free renames: `int`→`integer`, `token`→`string`) into `format-harmonization` (INFO): message affirms the value is valid as-is, and `suggestion` records the harmonized target (`date`/`dateTime`) for pipelines that migrate the datafile too. UIs distinguish the two categories by check id — dd-edit will render harmonization findings without a one-click button.

## Corpus-informed unit curation

From surveying the harvested corpus (1,540 dictionaries; 203 with unit columns; 29,177 cells, 939 distinct spellings):

- **Single-letter case flips are no longer suggested** — the corpus's second-most-common unit is `S` (siemens, 1,672 cells), which the case-fix rule turned into `s` (seconds). Exact single-letter codes still resolve; `l`→`L` survives as an explicit spelling (both mean liter in UCUM).
- **New curated units** the corpus writes constantly: `[ppm]`/`[ppb]`, `mg/L`+`ug/L` (with slashless `mgL`/`ugl` misprints), `uS/cm` (`uScm`), `kW.h` (`kWh`), `um` (micron), `cm2`/`mm2`/`m3`/`cm3`/`mm3`, `perc` → `%`.

Re-running the survey: exact recognition 6% → 9% of cells; the 3,222 wrong S/D suggestions are now silent; ~1,300 genuinely new suggestions appear.

All six suites pass (413 tests), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)