### PR TITLE
Validator: split datatype-preferred into WARNING and INFO by cost

### DIFF
--- a/validator/dd_validator/checks.py
+++ b/validator/dd_validator/checks.py
@@ -665,12 +665,14 @@ _PREFERRED_DATATYPE: dict[str, str] = {
 def check_datatype_preferred(
     rows: Iterable[RawRow], columns_present: set[str]
 ) -> Iterable[Finding]:
-    """Advisory: prefer the semantic datatype name (INFO; the value is valid).
+    """Advisory: prefer the semantic datatype name. Two levels, by cost.
 
     ``int``/``short``/``token`` name a storage width or lexical class and map
-    silently onto the semantic builtin anyway; the extension date formats
-    (``date_mdy``, ``timestamp``) render as generated custom types where the
-    native ``date``/``dateTime`` is usually meant.
+    silently onto the semantic builtin anyway — the rename is free and always
+    right, so it is a WARNING. The extension date formats (``date_mdy``,
+    ``timestamp``) truthfully describe the source data and are standard in
+    REDCap; renaming is only right once the data itself is converted, so they
+    stay INFO — a heads-up, not a problem.
     """
     if "Datatype" not in columns_present:
         return
@@ -680,18 +682,20 @@ def check_datatype_preferred(
         if preferred is None:
             continue
         if name in CUSTOM_TYPES:
+            level = Level.INFO
             message = (
-                f"datatype {name!r} renders as a generated custom type; prefer "
-                f"the native {preferred!r} unless the datafile really stores "
-                f"that format"
+                f"datatype {name!r} is a standard REDCap format (valid as-is); "
+                f"if the data is ever converted/harmonized, change to "
+                f"{preferred!r} to match"
             )
         else:
+            level = Level.WARNING
             message = (
                 f"datatype {name!r} names a storage width, not a meaning; "
                 f"the semantic type is {preferred!r}"
             )
         yield Finding(
-            Level.INFO, "datatype-preferred", message,
+            level, "datatype-preferred", message,
             line=row.line, column="Datatype", value=name, suggestion=preferred,
         )
 

--- a/validator/tests/test_checks.py
+++ b/validator/tests/test_checks.py
@@ -90,19 +90,24 @@ def test_cell_whitespace_skips_id_blank_and_whitespace_only_cells():
 
 # --- advisory: datatype-preferred -------------------------------------------
 
-def test_datatype_alias_prefers_semantic_name():
+def test_datatype_alias_warns_with_semantic_name():
+    # A pure rename: free and always right, so WARNING (not just INFO).
     (finding,) = list(check_datatype_preferred(_rows((2, {"Datatype": "int"})), {"Datatype"}))
-    assert finding.check == "datatype-preferred" and finding.level is Level.INFO
+    assert finding.check == "datatype-preferred" and finding.level is Level.WARNING
     assert finding.suggestion == "integer"
     assert "storage width" in finding.message
 
 
-def test_datatype_extension_format_prefers_native():
+def test_datatype_extension_format_is_an_info_heads_up():
+    # date_mdy truthfully describes REDCap source data; renaming is only
+    # right after the data itself is converted — INFO, and says so.
     (finding,) = list(
         check_datatype_preferred(_rows((2, {"Datatype": "date_mdy"})), {"Datatype"})
     )
+    assert finding.level is Level.INFO
     assert finding.suggestion == "date"
-    assert "custom type" in finding.message
+    assert "valid as-is" in finding.message
+    assert "converted/harmonized" in finding.message
 
 
 def test_datatype_semantic_and_deliberate_custom_names_are_silent():


### PR DESCRIPTION
## Summary
- `int`/`short`/`token`-style storage-width aliases: WARNING — the rename to the semantic builtin is free and always right
- `date_mdy`/`date_dmy`/`timestamp`: stay INFO — they truthfully describe REDCap source data, so the rename is only correct after the data itself is converted; the message now leads with "valid as-is" and phrases the condition as "if the data is ever converted/harmonized, change to … to match"
- Matches the softened wording dd-edit's inspector uses for the same situation

## Test plan
- Updated the two datatype-preferred tests (levels + new message text); `pytest validator/tests` — 91 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)